### PR TITLE
BI-8776 Fix bugs raised by Sonarqube

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ordernotification/orders/service/OrdersServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/orders/service/OrdersServiceException.java
@@ -5,6 +5,14 @@ package uk.gov.companieshouse.ordernotification.orders.service;
  */
 public class OrdersServiceException extends RuntimeException {
 
+    public OrdersServiceException(String message) {
+        super(message);
+    }
+
+    public OrdersServiceException(Throwable cause) {
+        super(cause);
+    }
+
     public OrdersServiceException(String message, Throwable throwable) {
         super(message, throwable);
     }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/DateGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/DateGeneratorTest.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DateGeneratorTest {
+class DateGeneratorTest {
 
     @Test
     void testGenerateDate() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/ordersconsumer/OrdersKafkaErrorConsumerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/ordersconsumer/OrdersKafkaErrorConsumerIntegrationTest.java
@@ -45,7 +45,7 @@ import static org.mockserver.model.HttpResponse.response;
 @EmbeddedKafka
 @Import(TestConfig.class)
 @TestPropertySource(locations = "classpath:application-stubbed-error-consumer.properties")
-public class OrdersKafkaErrorConsumerIntegrationTest {
+class OrdersKafkaErrorConsumerIntegrationTest {
     @Autowired
     private OrdersKafkaConsumer ordersKafkaConsumer;
 


### PR DESCRIPTION
* Throw OrdersServiceException if startup latch times out or is
interrupted (used by unit and integration tests only).
* Remove public modifier from several test classes.

Related:
[BI-8776](https://companieshouse.atlassian.net/browse/BI-8776)