### PR TITLE
BI-9550 Add liquidation handling to default, llp companies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <junit-jupiter-engine-version>5.7.0</junit-jupiter-engine-version>
-        <private-api-sdk-java.version>2.0.91</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.102</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <testcontainers.version>1.16.0</testcontainers.version>
         <sonar.exclusions>

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
@@ -21,6 +21,7 @@ public class CertificateOrderNotificationModel extends OrderModel {
     private String principalPlaceOfBusinessDetails;
     private String generalNatureOfBusinessInformation;
     private FeatureOptions featureOptions;
+    private String liquidatorsDetails;
 
     public String getCertificateType() {
         return certificateType;
@@ -142,6 +143,14 @@ public class CertificateOrderNotificationModel extends OrderModel {
         this.featureOptions = featureOptions;
     }
 
+    public String getLiquidatorsDetails() {
+        return liquidatorsDetails;
+    }
+
+    public void setLiquidatorsDetails(String liquidatorsDetails) {
+        this.liquidatorsDetails = liquidatorsDetails;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -168,7 +177,8 @@ public class CertificateOrderNotificationModel extends OrderModel {
                 Objects.equals(limitedPartnerDetails, that.limitedPartnerDetails) &&
                 Objects.equals(principalPlaceOfBusinessDetails, that.principalPlaceOfBusinessDetails) &&
                 Objects.equals(generalNatureOfBusinessInformation, that.generalNatureOfBusinessInformation) &&
-                Objects.equals(featureOptions, that.featureOptions);
+                Objects.equals(featureOptions, that.featureOptions) &&
+                Objects.equals(liquidatorsDetails, that.liquidatorsDetails);
     }
 
     @Override
@@ -176,6 +186,6 @@ public class CertificateOrderNotificationModel extends OrderModel {
         return Objects.hash(super.hashCode(), certificateType, statementOfGoodStanding, deliveryMethod,
                 registeredOfficeAddressDetails, directorDetailsModel, secretaryDetailsModel, companyObjects,
                 companyType, designatedMembersDetails, membersDetails, generalPartnerDetails, limitedPartnerDetails,
-                principalPlaceOfBusinessDetails, generalNatureOfBusinessInformation, featureOptions);
+                principalPlaceOfBusinessDetails, generalNatureOfBusinessInformation, featureOptions, liquidatorsDetails);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapper.java
@@ -9,16 +9,19 @@ import uk.gov.companieshouse.ordernotification.config.FeatureOptions;
 public class LLPCertificateOptionsMapper extends CertificateOptionsMapper {
     private final AddressRecordTypeMapper addressRecordTypeMapper;
     private final MembersDetailsApiMapper membersDetailsApiMapper;
+    private final LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
 
     @Autowired
     public LLPCertificateOptionsMapper(FeatureOptions featureOptions,
                                        CertificateTypeMapper certificateTypeMapper,
                                        AddressRecordTypeMapper addressRecordTypeMapper,
                                        DeliveryMethodMapper deliveryMethodMapper,
-                                       MembersDetailsApiMapper membersDetailsApiMapper) {
+                                       MembersDetailsApiMapper membersDetailsApiMapper,
+                                       LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper) {
         super(featureOptions, certificateTypeMapper, deliveryMethodMapper);
         this.addressRecordTypeMapper = addressRecordTypeMapper;
         this.membersDetailsApiMapper = membersDetailsApiMapper;
+        this.liquidatorsDetailsApiMapper = liquidatorsDetailsApiMapper;
     }
 
     @Override
@@ -26,5 +29,6 @@ public class LLPCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setRegisteredOfficeAddressDetails(addressRecordTypeMapper.mapAddressRecordType(source.getRegisteredOfficeAddressDetails().getIncludeAddressRecordsType()));
         destination.setDesignatedMembersDetails(membersDetailsApiMapper.map(source.getDesignatedMemberDetails()));
         destination.setMembersDetails(membersDetailsApiMapper.map(source.getMemberDetails()));
+        liquidatorsDetailsApiMapper.map(source, destination);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
-import uk.gov.companieshouse.api.model.order.item.LiquidatorsDetailsApi;
 
 import java.util.Optional;
 
@@ -12,7 +11,8 @@ public class LiquidatorsDetailsApiMapper {
     public void map(CertificateItemOptionsApi source, CertificateOrderNotificationModel target) {
         target.setLiquidatorsDetails(
                 Optional.ofNullable(source.getLiquidatorsDetails())
-                        .map(LiquidatorsDetailsApi::getIncludeBasicInformation)
+                        .map(liquidatorsDetails -> Optional.ofNullable(liquidatorsDetails.getIncludeBasicInformation())
+                                .orElse(Boolean.FALSE))
                         .map(MapUtil::mapBoolean).orElse(null));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
+import uk.gov.companieshouse.api.model.order.item.LiquidatorsDetailsApi;
+
+import java.util.Optional;
+
+@Component
+public class LiquidatorsDetailsApiMapper {
+
+    public void map(CertificateItemOptionsApi source, CertificateOrderNotificationModel target) {
+        target.setLiquidatorsDetails(
+                Optional.ofNullable(source.getLiquidatorsDetails())
+                        .map(LiquidatorsDetailsApi::getIncludeBasicInformation)
+                        .map(MapUtil::mapBoolean).orElse(null));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapper.java
@@ -10,16 +10,19 @@ public class OtherCertificateOptionsMapper extends CertificateOptionsMapper {
 
     private final AddressRecordTypeMapper addressRecordTypeMapper;
     private final DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
+    private final LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
 
     @Autowired
     public OtherCertificateOptionsMapper(FeatureOptions featureOptions,
                                          CertificateTypeMapper certificateTypeMapper,
                                          AddressRecordTypeMapper addressRecordTypeMapper,
                                          DeliveryMethodMapper deliveryMethodMapper,
-                                         DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper) {
+                                         DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper,
+                                         LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper) {
         super(featureOptions, certificateTypeMapper, deliveryMethodMapper);
         this.addressRecordTypeMapper = addressRecordTypeMapper;
         this.directorOrSecretaryDetailsApiMapper = directorOrSecretaryDetailsApiMapper;
+        this.liquidatorsDetailsApiMapper = liquidatorsDetailsApiMapper;
     }
 
     @Override
@@ -28,5 +31,6 @@ public class OtherCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setDirectorDetailsModel(directorOrSecretaryDetailsApiMapper.map(source.getDirectorDetails()));
         destination.setSecretaryDetailsModel(directorOrSecretaryDetailsApiMapper.map(source.getSecretaryDetails()));
         destination.setCompanyObjects(MapUtil.mapBoolean(source.getIncludeCompanyObjectsInformation()));
+        liquidatorsDetailsApiMapper.map(source, destination);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateTypeApi;
@@ -22,6 +21,8 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,12 +35,14 @@ class CertificateOptionsMapperTest {
     private DeliveryMethodMapper deliveryMethodMapper;
     @Mock
     private DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
+    @Mock
+    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
 
     @InjectMocks
     private OtherCertificateOptionsMapper otherCertificateOptionsMapper;
 
     @Test
-    void testCertificateOrderNotificationMapperMapsSuccessfully() throws JsonProcessingException {
+    void testCertificateOrderNotificationMapperMapsSuccessfully() {
         // given
         DirectorOrSecretaryDetailsApi appointmentDetails = new DirectorOrSecretaryDetailsApi();
         appointmentDetails.setIncludeAddress(true);
@@ -96,6 +99,7 @@ class CertificateOptionsMapperTest {
         expected.setCompanyObjects(TestConstants.READABLE_FALSE);
 
         assertEquals(expected, result);
+        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
     }
 
     private CertificateDetailsModel getCertificateDetailsModel() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapperTest.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +28,8 @@ class LLPCertificateOptionsMapperTest {
     private AddressRecordTypeMapper addressRecordTypeMapper;
     @Mock
     private MembersDetailsApiMapper membersDetailsApiMapper;
+    @Mock
+    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
 
     @InjectMocks
     private LLPCertificateOptionsMapper llpCertificateOptionsMapper;
@@ -66,6 +70,7 @@ class LLPCertificateOptionsMapperTest {
 
         // then
         assertEquals(getCertificateOrderNotificationModel(), result);
+        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
     }
 
     private CertificateOrderNotificationModel getCertificateOrderNotificationModel() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
@@ -60,7 +60,7 @@ public class LiquidatorsDetailsApiMapperTest {
     }
 
     @Test
-    void testSetLiquidatorsDetailsToNullIfLiquidatorsDetailsBasicInformationNull() {
+    void testSetLiquidatorsDetailsToNoIfLiquidatorsDetailsBasicInformationNull() {
         //given
         LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
@@ -72,6 +72,6 @@ public class LiquidatorsDetailsApiMapperTest {
         mapper.map(certificateItemOptions, model);
 
         //then
-        assertNull(model.getLiquidatorsDetails());
+        assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
+import uk.gov.companieshouse.api.model.order.item.LiquidatorsDetailsApi;
+import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class LiquidatorsDetailsApiMapperTest {
+
+    @Test
+    void testSetLiquidatorsDetailsToYesIfLiquidatorsDetailsTrue() {
+        //given
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
+        liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.TRUE);
+        CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
+        certificateItemOptionsApi.setLiquidatorsDetails(liquidatorsDetailsApi);
+
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(certificateItemOptionsApi, model);
+
+        //then
+        assertEquals(TestConstants.READABLE_TRUE, model.getLiquidatorsDetails());
+    }
+
+    @Test
+    void testSetLiquidatorsDetailsToNoIfLiquidatorsDetailsFalse() {
+        //given
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
+        liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.FALSE);
+        CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
+        certificateItemOptionsApi.setLiquidatorsDetails(liquidatorsDetailsApi);
+
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(certificateItemOptionsApi, model);
+
+        //then
+        assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
+    }
+
+    @Test
+    void testSetLiquidatorsDetailsToNullIfLiquidatorsDetailsAbsent() {
+        //given
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(new CertificateItemOptionsApi(), model);
+
+        //then
+        assertNull(model.getLiquidatorsDetails());
+    }
+
+    @Test
+    void testSetLiquidatorsDetailsToNullIfLiquidatorsDetailsBasicInformationNull() {
+        //given
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
+        CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
+        certificateItemOptions.setLiquidatorsDetails(liquidatorsDetailsApi);
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(certificateItemOptions, model);
+
+        //then
+        assertNull(model.getLiquidatorsDetails());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapperTest.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +27,8 @@ class OtherCertificateOptionsMapperTest {
     private AddressRecordTypeMapper addressRecordTypeMapper;
     @Mock
     private DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
+    @Mock
+    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
 
     @InjectMocks
     private OtherCertificateOptionsMapper otherCertificateOptionsMapper;
@@ -61,6 +65,7 @@ class OtherCertificateOptionsMapperTest {
 
         // then
         assertEquals(getCertificateOrderNotificationModel(), result);
+        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
     }
 
     private CertificateOrderNotificationModel getCertificateOrderNotificationModel() {


### PR DESCRIPTION
* Add liquidation details field to certificate model
* Implement mapper to conditionally map liquidation details object from
  order resource to certificate model.
* If liquidation_details null or field value null then field will be
  absent from transformed model.
* Tested locally, working.

Resolves:
[BI-9550](https://companieshouse.atlassian.net/browse/BI-9550)