### PR TITLE
DEBT-1554 Upgrade Log4J to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>latest</version>
     <properties>
         <java.version>1.8</java.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <spring-boot-dependencies.version>2.4.4</spring-boot-dependencies.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
- Upgrade Log4J to 2.17.0
- 
[dependency-tree.txt](https://github.com/companieshouse/order-notification-sender/files/7744609/dependency-tree.txt)

Related to: [Security Fix: Upgrade order-notification-sender to 2.17.0](https://companieshouse.atlassian.net/browse/DEBT-1554)