### PR TITLE
BI-10576 Conditional rendering of statement of good standing and liquidators details

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapper.java
@@ -24,7 +24,6 @@ public abstract class CertificateOptionsMapper {
         model.setCompanyName(item.getCompanyName());
         model.setCompanyNumber(item.getCompanyNumber());
         model.setCertificateType(getCertificateTypeMapper().mapCertificateType(itemOptions.getCertificateType()));
-        model.setStatementOfGoodStanding(MapUtil.mapBoolean(itemOptions.getIncludeGoodStandingInformation()));
         model.setDeliveryMethod(getDeliveryMethodMapper().mapDeliveryMethod(itemOptions.getDeliveryMethod(), itemOptions.getDeliveryTimescale()));
         model.setFeatureOptions(featureOptions);
 
@@ -42,6 +41,4 @@ public abstract class CertificateOptionsMapper {
     protected DeliveryMethodMapper getDeliveryMethodMapper() {
         return deliveryMethodMapper;
     }
-
-
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
@@ -23,7 +23,7 @@ public class CertificateOrderNotificationModel extends OrderModel {
     private String generalNatureOfBusinessInformation;
     private FeatureOptions featureOptions;
     private String liquidatorsDetails;
-    private boolean renderLiquidatorDetails;
+    private boolean renderLiquidatorsDetails;
 
     public String getCertificateType() {
         return certificateType;
@@ -161,12 +161,12 @@ public class CertificateOrderNotificationModel extends OrderModel {
         this.liquidatorsDetails = liquidatorsDetails;
     }
 
-    public boolean isRenderLiquidatorDetails() {
-        return renderLiquidatorDetails;
+    public boolean isRenderLiquidatorsDetails() {
+        return renderLiquidatorsDetails;
     }
 
-    public void setRenderLiquidatorDetails(boolean renderLiquidatorDetails) {
-        this.renderLiquidatorDetails = renderLiquidatorDetails;
+    public void setRenderLiquidatorsDetails(boolean renderLiquidatorsDetails) {
+        this.renderLiquidatorsDetails = renderLiquidatorsDetails;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
@@ -8,6 +8,7 @@ public class CertificateOrderNotificationModel extends OrderModel {
 
     private String certificateType;
     private String statementOfGoodStanding;
+    private boolean renderStatementOfGoodStanding;
     private String deliveryMethod;
     private String registeredOfficeAddressDetails;
     private CertificateDetailsModel directorDetailsModel;
@@ -22,6 +23,7 @@ public class CertificateOrderNotificationModel extends OrderModel {
     private String generalNatureOfBusinessInformation;
     private FeatureOptions featureOptions;
     private String liquidatorsDetails;
+    private boolean renderLiquidatorDetails;
 
     public String getCertificateType() {
         return certificateType;
@@ -37,6 +39,14 @@ public class CertificateOrderNotificationModel extends OrderModel {
 
     public void setStatementOfGoodStanding(String statementOfGoodStanding) {
         this.statementOfGoodStanding = statementOfGoodStanding;
+    }
+
+    public boolean isRenderStatementOfGoodStanding() {
+        return renderStatementOfGoodStanding;
+    }
+
+    public void setRenderStatementOfGoodStanding(boolean renderStatementOfGoodStanding) {
+        this.renderStatementOfGoodStanding = renderStatementOfGoodStanding;
     }
 
     public String getDeliveryMethod() {
@@ -149,6 +159,14 @@ public class CertificateOrderNotificationModel extends OrderModel {
 
     public void setLiquidatorsDetails(String liquidatorsDetails) {
         this.liquidatorsDetails = liquidatorsDetails;
+    }
+
+    public boolean isRenderLiquidatorDetails() {
+        return renderLiquidatorDetails;
+    }
+
+    public void setRenderLiquidatorDetails(boolean renderLiquidatorDetails) {
+        this.renderLiquidatorDetails = renderLiquidatorDetails;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOrderNotificationModel.java
@@ -7,8 +7,7 @@ import java.util.Objects;
 public class CertificateOrderNotificationModel extends OrderModel {
 
     private String certificateType;
-    private String statementOfGoodStanding;
-    private boolean renderStatementOfGoodStanding;
+    private Content<String> statementOfGoodStanding;
     private String deliveryMethod;
     private String registeredOfficeAddressDetails;
     private CertificateDetailsModel directorDetailsModel;
@@ -22,8 +21,7 @@ public class CertificateOrderNotificationModel extends OrderModel {
     private String principalPlaceOfBusinessDetails;
     private String generalNatureOfBusinessInformation;
     private FeatureOptions featureOptions;
-    private String liquidatorsDetails;
-    private boolean renderLiquidatorsDetails;
+    private Content<String> liquidatorsDetails;
 
     public String getCertificateType() {
         return certificateType;
@@ -33,20 +31,12 @@ public class CertificateOrderNotificationModel extends OrderModel {
         this.certificateType = certificateType;
     }
 
-    public String getStatementOfGoodStanding() {
+    public Content<String> getStatementOfGoodStanding() {
         return statementOfGoodStanding;
     }
 
-    public void setStatementOfGoodStanding(String statementOfGoodStanding) {
+    public void setStatementOfGoodStanding(Content<String> statementOfGoodStanding) {
         this.statementOfGoodStanding = statementOfGoodStanding;
-    }
-
-    public boolean isRenderStatementOfGoodStanding() {
-        return renderStatementOfGoodStanding;
-    }
-
-    public void setRenderStatementOfGoodStanding(boolean renderStatementOfGoodStanding) {
-        this.renderStatementOfGoodStanding = renderStatementOfGoodStanding;
     }
 
     public String getDeliveryMethod() {
@@ -153,20 +143,12 @@ public class CertificateOrderNotificationModel extends OrderModel {
         this.featureOptions = featureOptions;
     }
 
-    public String getLiquidatorsDetails() {
+    public Content<String> getLiquidatorsDetails() {
         return liquidatorsDetails;
     }
 
-    public void setLiquidatorsDetails(String liquidatorsDetails) {
+    public void setLiquidatorsDetails(Content<String> liquidatorsDetails) {
         this.liquidatorsDetails = liquidatorsDetails;
-    }
-
-    public boolean isRenderLiquidatorsDetails() {
-        return renderLiquidatorsDetails;
-    }
-
-    public void setRenderLiquidatorsDetails(boolean renderLiquidatorsDetails) {
-        this.renderLiquidatorsDetails = renderLiquidatorsDetails;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatus.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatus.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum CompanyStatus {
+    LIQUIDATION("liquidation");
+
+    private static final Map<String, CompanyStatus> enumValues;
+
+    static {
+        enumValues = Arrays.stream(values())
+                .collect(Collectors.toMap(CompanyStatus::toString, Function.identity()));
+    }
+
+    private final String statusName;
+
+    CompanyStatus(String companyStatus) {
+        this.statusName = companyStatus;
+    }
+
+    public static CompanyStatus getEnumValue(String companyStatus) {
+        return companyStatus != null ? enumValues.get(companyStatus) : null;
+    }
+
+    @Override
+    public String toString() {
+        return statusName;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapper.java
@@ -11,18 +11,15 @@ public class CompanyStatusMapper {
     public void map(CertificateItemOptionsApi source, CertificateOrderNotificationModel target) {
         if (CompanyStatus.LIQUIDATION == CompanyStatus.getEnumValue(source.getCompanyStatus())) {
             if (!isNull(source.getLiquidatorsDetails())) {
-                target.setLiquidatorsDetails(MapUtil.mapBoolean(source.getLiquidatorsDetails()
-                        .getIncludeBasicInformation()));
-                target.setRenderLiquidatorsDetails(true);
+                target.setLiquidatorsDetails(new Content<>(MapUtil.mapBoolean(source.getLiquidatorsDetails()
+                        .getIncludeBasicInformation())));
             } else {
                 target.setLiquidatorsDetails(null);
-                target.setRenderLiquidatorsDetails(false);
             }
-            target.setRenderStatementOfGoodStanding(false);
+            target.setStatementOfGoodStanding(null);
         } else {
-            target.setStatementOfGoodStanding(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation()));
-            target.setRenderStatementOfGoodStanding(true);
-            target.setRenderLiquidatorsDetails(false);
+            target.setLiquidatorsDetails(null);
+            target.setStatementOfGoodStanding(new Content<>(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation())));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapper.java
@@ -6,23 +6,23 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
 
 @Component
-public class LiquidatorsDetailsApiMapper {
+public class CompanyStatusMapper {
 
     public void map(CertificateItemOptionsApi source, CertificateOrderNotificationModel target) {
         if (CompanyStatus.LIQUIDATION == CompanyStatus.getEnumValue(source.getCompanyStatus())) {
             if (!isNull(source.getLiquidatorsDetails())) {
                 target.setLiquidatorsDetails(MapUtil.mapBoolean(source.getLiquidatorsDetails()
                         .getIncludeBasicInformation()));
-                target.setRenderLiquidatorDetails(true);
+                target.setRenderLiquidatorsDetails(true);
             } else {
                 target.setLiquidatorsDetails(null);
-                target.setRenderLiquidatorDetails(false);
+                target.setRenderLiquidatorsDetails(false);
             }
             target.setRenderStatementOfGoodStanding(false);
         } else {
             target.setStatementOfGoodStanding(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation()));
             target.setRenderStatementOfGoodStanding(true);
-            target.setRenderLiquidatorDetails(false);
+            target.setRenderLiquidatorsDetails(false);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/Content.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/Content.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import java.util.Objects;
+
+public class Content<T> {
+    private T content;
+
+    public Content(T content) {
+        this.content = content;
+    }
+
+    public T getContent() {
+        return content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Content<?> content1 = (Content<?>) o;
+        return Objects.equals(content, content1.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapper.java
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.ordernotification.config.FeatureOptions;
 public class LLPCertificateOptionsMapper extends CertificateOptionsMapper {
     private final AddressRecordTypeMapper addressRecordTypeMapper;
     private final MembersDetailsApiMapper membersDetailsApiMapper;
-    private final LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
+    private final CompanyStatusMapper companyStatusMapper;
 
     @Autowired
     public LLPCertificateOptionsMapper(FeatureOptions featureOptions,
@@ -17,11 +17,11 @@ public class LLPCertificateOptionsMapper extends CertificateOptionsMapper {
                                        AddressRecordTypeMapper addressRecordTypeMapper,
                                        DeliveryMethodMapper deliveryMethodMapper,
                                        MembersDetailsApiMapper membersDetailsApiMapper,
-                                       LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper) {
+                                       CompanyStatusMapper companyStatusMapper) {
         super(featureOptions, certificateTypeMapper, deliveryMethodMapper);
         this.addressRecordTypeMapper = addressRecordTypeMapper;
         this.membersDetailsApiMapper = membersDetailsApiMapper;
-        this.liquidatorsDetailsApiMapper = liquidatorsDetailsApiMapper;
+        this.companyStatusMapper = companyStatusMapper;
     }
 
     @Override
@@ -29,6 +29,6 @@ public class LLPCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setRegisteredOfficeAddressDetails(addressRecordTypeMapper.mapAddressRecordType(source.getRegisteredOfficeAddressDetails().getIncludeAddressRecordsType()));
         destination.setDesignatedMembersDetails(membersDetailsApiMapper.map(source.getDesignatedMemberDetails()));
         destination.setMembersDetails(membersDetailsApiMapper.map(source.getMemberDetails()));
-        liquidatorsDetailsApiMapper.map(source, destination);
+        companyStatusMapper.map(source, destination);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapper.java
@@ -24,7 +24,6 @@ public class LPCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setGeneralPartnerDetails(MapUtil.mapBoolean(source.getGeneralPartnerDetails().getIncludeBasicInformation()));
         destination.setLimitedPartnerDetails(MapUtil.mapBoolean(source.getLimitedPartnerDetails().getIncludeBasicInformation()));
         destination.setGeneralNatureOfBusinessInformation(MapUtil.mapBoolean(source.getIncludeGeneralNatureOfBusinessInformation()));
-        destination.setStatementOfGoodStanding(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation()));
-        destination.setRenderStatementOfGoodStanding(true);
+        destination.setStatementOfGoodStanding(new Content<>(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation())));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapper.java
@@ -24,5 +24,7 @@ public class LPCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setGeneralPartnerDetails(MapUtil.mapBoolean(source.getGeneralPartnerDetails().getIncludeBasicInformation()));
         destination.setLimitedPartnerDetails(MapUtil.mapBoolean(source.getLimitedPartnerDetails().getIncludeBasicInformation()));
         destination.setGeneralNatureOfBusinessInformation(MapUtil.mapBoolean(source.getIncludeGeneralNatureOfBusinessInformation()));
+        destination.setStatementOfGoodStanding(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation()));
+        destination.setRenderStatementOfGoodStanding(true);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapper.java
@@ -1,18 +1,28 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import static java.util.Objects.isNull;
+
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
-
-import java.util.Optional;
 
 @Component
 public class LiquidatorsDetailsApiMapper {
 
     public void map(CertificateItemOptionsApi source, CertificateOrderNotificationModel target) {
-        target.setLiquidatorsDetails(
-                Optional.ofNullable(source.getLiquidatorsDetails())
-                        .map(liquidatorsDetails -> Optional.ofNullable(liquidatorsDetails.getIncludeBasicInformation())
-                                .orElse(Boolean.FALSE))
-                        .map(MapUtil::mapBoolean).orElse(null));
+        if (CompanyStatus.LIQUIDATION == CompanyStatus.getEnumValue(source.getCompanyStatus())) {
+            if (!isNull(source.getLiquidatorsDetails())) {
+                target.setLiquidatorsDetails(MapUtil.mapBoolean(source.getLiquidatorsDetails()
+                        .getIncludeBasicInformation()));
+                target.setRenderLiquidatorDetails(true);
+            } else {
+                target.setLiquidatorsDetails(null);
+                target.setRenderLiquidatorDetails(false);
+            }
+            target.setRenderStatementOfGoodStanding(false);
+        } else {
+            target.setStatementOfGoodStanding(MapUtil.mapBoolean(source.getIncludeGoodStandingInformation()));
+            target.setRenderStatementOfGoodStanding(true);
+            target.setRenderLiquidatorDetails(false);
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapper.java
@@ -10,7 +10,7 @@ public class OtherCertificateOptionsMapper extends CertificateOptionsMapper {
 
     private final AddressRecordTypeMapper addressRecordTypeMapper;
     private final DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
-    private final LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
+    private final CompanyStatusMapper companyStatusMapper;
 
     @Autowired
     public OtherCertificateOptionsMapper(FeatureOptions featureOptions,
@@ -18,11 +18,11 @@ public class OtherCertificateOptionsMapper extends CertificateOptionsMapper {
                                          AddressRecordTypeMapper addressRecordTypeMapper,
                                          DeliveryMethodMapper deliveryMethodMapper,
                                          DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper,
-                                         LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper) {
+                                         CompanyStatusMapper companyStatusMapper) {
         super(featureOptions, certificateTypeMapper, deliveryMethodMapper);
         this.addressRecordTypeMapper = addressRecordTypeMapper;
         this.directorOrSecretaryDetailsApiMapper = directorOrSecretaryDetailsApiMapper;
-        this.liquidatorsDetailsApiMapper = liquidatorsDetailsApiMapper;
+        this.companyStatusMapper = companyStatusMapper;
     }
 
     @Override
@@ -31,6 +31,6 @@ public class OtherCertificateOptionsMapper extends CertificateOptionsMapper {
         destination.setDirectorDetailsModel(directorOrSecretaryDetailsApiMapper.map(source.getDirectorDetails()));
         destination.setSecretaryDetailsModel(directorOrSecretaryDetailsApiMapper.map(source.getSecretaryDetails()));
         destination.setCompanyObjects(MapUtil.mapBoolean(source.getIncludeCompanyObjectsInformation()));
-        liquidatorsDetailsApiMapper.map(source, destination);
+        companyStatusMapper.map(source, destination);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
@@ -35,8 +36,8 @@ class CertificateOptionsMapperTest {
     private DeliveryMethodMapper deliveryMethodMapper;
     @Mock
     private DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
-    @Mock
-    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
+    @Spy
+    private CompanyStatusMapper companyStatusMapper;
 
     @InjectMocks
     private OtherCertificateOptionsMapper otherCertificateOptionsMapper;
@@ -92,6 +93,7 @@ class CertificateOptionsMapperTest {
         expected.setCompanyNumber(TestConstants.COMPANY_NUMBER);
         expected.setCertificateType(TestConstants.CERTIFICATE_TYPE);
         expected.setStatementOfGoodStanding(TestConstants.READABLE_TRUE);
+        expected.setRenderStatementOfGoodStanding(true);
         expected.setDeliveryMethod(TestConstants.DELIVERY_METHOD);
         expected.setRegisteredOfficeAddressDetails(TestConstants.EXPECTED_ADDRESS_TYPE);
         expected.setDirectorDetailsModel(getCertificateDetailsModel());
@@ -99,7 +101,7 @@ class CertificateOptionsMapperTest {
         expected.setCompanyObjects(TestConstants.READABLE_FALSE);
 
         assertEquals(expected, result);
-        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
+        verify(companyStatusMapper).map(eq(itemOptions), any());
     }
 
     private CertificateDetailsModel getCertificateDetailsModel() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertificateOptionsMapperTest.java
@@ -92,8 +92,7 @@ class CertificateOptionsMapperTest {
         expected.setCompanyName(TestConstants.COMPANY_NAME);
         expected.setCompanyNumber(TestConstants.COMPANY_NUMBER);
         expected.setCertificateType(TestConstants.CERTIFICATE_TYPE);
-        expected.setStatementOfGoodStanding(TestConstants.READABLE_TRUE);
-        expected.setRenderStatementOfGoodStanding(true);
+        expected.setStatementOfGoodStanding(new Content<>(TestConstants.READABLE_TRUE));
         expected.setDeliveryMethod(TestConstants.DELIVERY_METHOD);
         expected.setRegisteredOfficeAddressDetails(TestConstants.EXPECTED_ADDRESS_TYPE);
         expected.setDirectorDetailsModel(getCertificateDetailsModel());

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapperTest.java
@@ -28,10 +28,8 @@ class CompanyStatusMapperTest {
         mapper.map(certificateItemOptionsApi, model);
 
         //then
-        assertEquals(TestConstants.READABLE_TRUE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorsDetails());
+        assertEquals(new Content<>(TestConstants.READABLE_TRUE), model.getLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
-        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -50,10 +48,8 @@ class CompanyStatusMapperTest {
         mapper.map(certificateItemOptionsApi, model);
 
         //then
-        assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorsDetails());
+        assertEquals(new Content<>(TestConstants.READABLE_FALSE), model.getLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
-        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -69,9 +65,7 @@ class CompanyStatusMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
-        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -88,10 +82,8 @@ class CompanyStatusMapperTest {
         mapper.map(certificateItemOptions, model);
 
         //then
-        assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorsDetails());
+        assertEquals(new Content<>(TestConstants.READABLE_FALSE), model.getLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
-        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -108,9 +100,7 @@ class CompanyStatusMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorsDetails());
-        assertEquals(TestConstants.READABLE_FALSE, model.getStatementOfGoodStanding());
-        assertTrue(model.isRenderStatementOfGoodStanding());
+        assertEquals(new Content<>(TestConstants.READABLE_FALSE), model.getStatementOfGoodStanding());
     }
 
     @Test
@@ -127,8 +117,6 @@ class CompanyStatusMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorsDetails());
-        assertEquals(TestConstants.READABLE_TRUE, model.getStatementOfGoodStanding());
-        assertTrue(model.isRenderStatementOfGoodStanding());
+        assertEquals(new Content<>(TestConstants.READABLE_TRUE), model.getStatementOfGoodStanding());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CompanyStatusMapperTest.java
@@ -10,12 +10,12 @@ import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
 import uk.gov.companieshouse.api.model.order.item.LiquidatorsDetailsApi;
 import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
 
-public class LiquidatorsDetailsApiMapperTest {
+class CompanyStatusMapperTest {
 
     @Test
     void testSetLiquidatorsDetailsToYesIfLiquidatorsDetailsTrue() {
         //given
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.TRUE);
         CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
@@ -29,7 +29,7 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_TRUE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorDetails());
+        assertTrue(model.isRenderLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
         assertFalse(model.isRenderStatementOfGoodStanding());
     }
@@ -37,7 +37,7 @@ public class LiquidatorsDetailsApiMapperTest {
     @Test
     void testSetLiquidatorsDetailsToNoIfLiquidatorsDetailsFalse() {
         //given
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.FALSE);
         CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
@@ -51,7 +51,7 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorDetails());
+        assertTrue(model.isRenderLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
         assertFalse(model.isRenderStatementOfGoodStanding());
     }
@@ -59,7 +59,7 @@ public class LiquidatorsDetailsApiMapperTest {
     @Test
     void testSetLiquidatorsDetailsToNullIfLiquidatorsDetailsAbsent() {
         //given
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
         CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
         certificateItemOptions.setCompanyStatus("liquidation");
@@ -69,7 +69,7 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorDetails());
+        assertFalse(model.isRenderLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
         assertFalse(model.isRenderStatementOfGoodStanding());
     }
@@ -77,7 +77,7 @@ public class LiquidatorsDetailsApiMapperTest {
     @Test
     void testSetLiquidatorsDetailsToNoIfLiquidatorsDetailsBasicInformationNull() {
         //given
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
         certificateItemOptions.setLiquidatorsDetails(liquidatorsDetailsApi);
@@ -89,14 +89,14 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
-        assertTrue(model.isRenderLiquidatorDetails());
+        assertTrue(model.isRenderLiquidatorsDetails());
         assertNull(model.getStatementOfGoodStanding());
         assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
     void testStatementOfGoodStandingRenderedAndSetToNoIfCompanyNotInLiquidationAndIncludeStatementOfGoodStandingIsFalse() {
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
         certificateItemOptions.setIncludeGoodStandingInformation(false);
@@ -108,14 +108,14 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorDetails());
+        assertFalse(model.isRenderLiquidatorsDetails());
         assertEquals(TestConstants.READABLE_FALSE, model.getStatementOfGoodStanding());
         assertTrue(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
     void testStatementOfGoodStandingRenderedAndSetToYesIfCompanyNotInLiquidationAndIncludeStatementOfGoodStandingIsTrue() {
-        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        CompanyStatusMapper mapper = new CompanyStatusMapper();
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
         certificateItemOptions.setIncludeGoodStandingInformation(true);
@@ -127,7 +127,7 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertNull(model.getLiquidatorsDetails());
-        assertFalse(model.isRenderLiquidatorDetails());
+        assertFalse(model.isRenderLiquidatorsDetails());
         assertEquals(TestConstants.READABLE_TRUE, model.getStatementOfGoodStanding());
         assertTrue(model.isRenderStatementOfGoodStanding());
     }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LLPCertificateOptionsMapperTest.java
@@ -29,7 +29,7 @@ class LLPCertificateOptionsMapperTest {
     @Mock
     private MembersDetailsApiMapper membersDetailsApiMapper;
     @Mock
-    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
+    private CompanyStatusMapper companyStatusMapper;
 
     @InjectMocks
     private LLPCertificateOptionsMapper llpCertificateOptionsMapper;
@@ -70,7 +70,7 @@ class LLPCertificateOptionsMapperTest {
 
         // then
         assertEquals(getCertificateOrderNotificationModel(), result);
-        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
+        verify(companyStatusMapper).map(eq(itemOptions), any());
     }
 
     private CertificateOrderNotificationModel getCertificateOrderNotificationModel() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapperTest.java
@@ -52,11 +52,15 @@ class LPCertificateOptionsMapperTest {
 
         when(addressRecordTypeMapper.mapAddressRecordType(any())).thenReturn(TestConstants.ADDRESS_TYPE);
 
+        CertificateOrderNotificationModel expected = getCertificateOrderNotificationModel();
+        expected.setStatementOfGoodStanding("No");
+        expected.setRenderStatementOfGoodStanding(true);
+
         // when
         lpCertificateOptionsMapper.doMapCustomData(itemOptions, result);
 
         // then
-        assertEquals(getCertificateOrderNotificationModel(), result);
+        assertEquals(expected, result);
     }
 
     private CertificateOrderNotificationModel getCertificateOrderNotificationModel() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LPCertificateOptionsMapperTest.java
@@ -53,8 +53,7 @@ class LPCertificateOptionsMapperTest {
         when(addressRecordTypeMapper.mapAddressRecordType(any())).thenReturn(TestConstants.ADDRESS_TYPE);
 
         CertificateOrderNotificationModel expected = getCertificateOrderNotificationModel();
-        expected.setStatementOfGoodStanding("No");
-        expected.setRenderStatementOfGoodStanding(true);
+        expected.setStatementOfGoodStanding(new Content<>("No"));
 
         // when
         lpCertificateOptionsMapper.doMapCustomData(itemOptions, result);

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/LiquidatorsDetailsApiMapperTest.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.model.order.item.CertificateItemOptionsApi;
 import uk.gov.companieshouse.api.model.order.item.LiquidatorsDetailsApi;
 import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LiquidatorsDetailsApiMapperTest {
 
@@ -18,6 +20,7 @@ public class LiquidatorsDetailsApiMapperTest {
         liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.TRUE);
         CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
         certificateItemOptionsApi.setLiquidatorsDetails(liquidatorsDetailsApi);
+        certificateItemOptionsApi.setCompanyStatus("liquidation");
 
         CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
 
@@ -26,6 +29,9 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_TRUE, model.getLiquidatorsDetails());
+        assertTrue(model.isRenderLiquidatorDetails());
+        assertNull(model.getStatementOfGoodStanding());
+        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -36,6 +42,7 @@ public class LiquidatorsDetailsApiMapperTest {
         liquidatorsDetailsApi.setIncludeBasicInformation(Boolean.FALSE);
         CertificateItemOptionsApi certificateItemOptionsApi = new CertificateItemOptionsApi();
         certificateItemOptionsApi.setLiquidatorsDetails(liquidatorsDetailsApi);
+        certificateItemOptionsApi.setCompanyStatus("liquidation");
 
         CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
 
@@ -44,6 +51,9 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
+        assertTrue(model.isRenderLiquidatorDetails());
+        assertNull(model.getStatementOfGoodStanding());
+        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -51,12 +61,17 @@ public class LiquidatorsDetailsApiMapperTest {
         //given
         LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
         CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+        CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
+        certificateItemOptions.setCompanyStatus("liquidation");
 
         //when
-        mapper.map(new CertificateItemOptionsApi(), model);
+        mapper.map(certificateItemOptions, model);
 
         //then
         assertNull(model.getLiquidatorsDetails());
+        assertFalse(model.isRenderLiquidatorDetails());
+        assertNull(model.getStatementOfGoodStanding());
+        assertFalse(model.isRenderStatementOfGoodStanding());
     }
 
     @Test
@@ -66,6 +81,7 @@ public class LiquidatorsDetailsApiMapperTest {
         LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
         CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
         certificateItemOptions.setLiquidatorsDetails(liquidatorsDetailsApi);
+        certificateItemOptions.setCompanyStatus("liquidation");
         CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
 
         //when
@@ -73,5 +89,46 @@ public class LiquidatorsDetailsApiMapperTest {
 
         //then
         assertEquals(TestConstants.READABLE_FALSE, model.getLiquidatorsDetails());
+        assertTrue(model.isRenderLiquidatorDetails());
+        assertNull(model.getStatementOfGoodStanding());
+        assertFalse(model.isRenderStatementOfGoodStanding());
+    }
+
+    @Test
+    void testStatementOfGoodStandingRenderedAndSetToNoIfCompanyNotInLiquidationAndIncludeStatementOfGoodStandingIsFalse() {
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
+        CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
+        certificateItemOptions.setIncludeGoodStandingInformation(false);
+        certificateItemOptions.setCompanyStatus("active");
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(certificateItemOptions, model);
+
+        //then
+        assertNull(model.getLiquidatorsDetails());
+        assertFalse(model.isRenderLiquidatorDetails());
+        assertEquals(TestConstants.READABLE_FALSE, model.getStatementOfGoodStanding());
+        assertTrue(model.isRenderStatementOfGoodStanding());
+    }
+
+    @Test
+    void testStatementOfGoodStandingRenderedAndSetToYesIfCompanyNotInLiquidationAndIncludeStatementOfGoodStandingIsTrue() {
+        LiquidatorsDetailsApiMapper mapper = new LiquidatorsDetailsApiMapper();
+        LiquidatorsDetailsApi liquidatorsDetailsApi = new LiquidatorsDetailsApi();
+        CertificateItemOptionsApi certificateItemOptions = new CertificateItemOptionsApi();
+        certificateItemOptions.setIncludeGoodStandingInformation(true);
+        certificateItemOptions.setCompanyStatus("active");
+        CertificateOrderNotificationModel model = new CertificateOrderNotificationModel();
+
+        //when
+        mapper.map(certificateItemOptions, model);
+
+        //then
+        assertNull(model.getLiquidatorsDetails());
+        assertFalse(model.isRenderLiquidatorDetails());
+        assertEquals(TestConstants.READABLE_TRUE, model.getStatementOfGoodStanding());
+        assertTrue(model.isRenderStatementOfGoodStanding());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OtherCertificateOptionsMapperTest.java
@@ -28,7 +28,7 @@ class OtherCertificateOptionsMapperTest {
     @Mock
     private DirectorOrSecretaryDetailsApiMapper directorOrSecretaryDetailsApiMapper;
     @Mock
-    private LiquidatorsDetailsApiMapper liquidatorsDetailsApiMapper;
+    private CompanyStatusMapper companyStatusMapper;
 
     @InjectMocks
     private OtherCertificateOptionsMapper otherCertificateOptionsMapper;
@@ -65,7 +65,7 @@ class OtherCertificateOptionsMapperTest {
 
         // then
         assertEquals(getCertificateOrderNotificationModel(), result);
-        verify(liquidatorsDetailsApiMapper).map(eq(itemOptions), any());
+        verify(companyStatusMapper).map(eq(itemOptions), any());
     }
 
     private CertificateOrderNotificationModel getCertificateOrderNotificationModel() {


### PR DESCRIPTION
* Added CompanyStatus enumeration
* Changed mapping logic to conditionally [company status] set good standing or liquidators details fields in the certificate order notification model
* LP companies map statement of good standing only for rendering
* LLP & other companies conditionally map either  statement of good standing or liquidators details for rendering

Relates to: [BI-10576 order_notification_sender: add statement of statement of good standing & liquidators details business logic](https://companieshouse.atlassian.net/browse/BI-10576)