### PR TITLE
GCI-2239 Implement mapping algorithm in summary email data director

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/NonRetryableFailureException.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/NonRetryableFailureException.java
@@ -5,6 +5,10 @@ package uk.gov.companieshouse.ordernotification.emailsender;
  */
 public class NonRetryableFailureException extends RuntimeException {
 
+    public NonRetryableFailureException(String message) {
+        super(message);
+    }
+
     public NonRetryableFailureException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/Kind.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/Kind.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Kind {
+    CERTIFICATE("item#certificate"),
+    CERTIFIED_COPY("item#certified-copy"),
+    MISSING_IMAGE_DELIVERY("item#missing-image-delivery");
+
+    private static final Map<String, Kind> enumValues;
+
+    static {
+        enumValues = Arrays.stream(values())
+                .collect(Collectors.toMap(Kind::toString, Function.identity()));
+    }
+
+    private final String kind;
+
+    Kind(String kind) {
+        this.kind = kind;
+    }
+
+    public static Kind getEnumValue(String kind) {
+        return kind != null ? enumValues.get(kind) : null;
+    }
+
+    @Override
+    public String toString() {
+        return kind;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
@@ -1,8 +1,14 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE, proxyMode = ScopedProxyMode.INTERFACES)
 public class OrderNotificationEmailDataConverter implements OrderNotificationDataConvertable {
 
     private OrderNotificationEmailData emailData;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
@@ -1,9 +1,33 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
+import uk.gov.companieshouse.ordernotification.emailsender.NonRetryableFailureException;
 
+@Component
 public class SummaryEmailDataDirector {
-    public OrderNotificationEmailData map(OrdersApi ordersApi){
-        return null;
+
+    private final OrderNotificationDataConvertable converter;
+
+    public SummaryEmailDataDirector(OrderNotificationDataConvertable converter) {
+        this.converter = converter;
+    }
+
+    public OrderNotificationEmailData map(OrdersApi ordersApi) {
+        converter.mapOrder(ordersApi);
+        for (BaseItemApi itemApi: ordersApi.getItems()) {
+            String kind = itemApi.getKind();
+            if ("item#certificate".equals(kind)) {
+                converter.mapCertificate(itemApi);
+            } else if ("item#certified-copy".equals(kind)) {
+                converter.mapCertifiedCopy(itemApi);
+            } else if ("item#missing-image-delivery".equals(kind)) {
+                converter.mapMissingImageDelivery(itemApi);
+            } else {
+                throw new NonRetryableFailureException(String.format("Unhandled kind: [%s]", kind));
+            }
+        }
+        return converter.getEmailData();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
@@ -18,11 +18,11 @@ public class SummaryEmailDataDirector {
         converter.mapOrder(ordersApi);
         for (BaseItemApi itemApi: ordersApi.getItems()) {
             String kind = itemApi.getKind();
-            if ("item#certificate".equals(kind)) {
+            if (Kind.CERTIFICATE.toString().equals(kind)) {
                 converter.mapCertificate(itemApi);
-            } else if ("item#certified-copy".equals(kind)) {
+            } else if (Kind.CERTIFIED_COPY.toString().equals(kind)) {
                 converter.mapCertifiedCopy(itemApi);
-            } else if ("item#missing-image-delivery".equals(kind)) {
+            } else if (Kind.MISSING_IMAGE_DELIVERY.toString().equals(kind)) {
                 converter.mapMissingImageDelivery(itemApi);
             } else {
                 throw new NonRetryableFailureException(String.format("Unhandled kind: [%s]", kind));

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirectorTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirectorTest.java
@@ -1,0 +1,94 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.api.model.order.OrdersApi;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
+import uk.gov.companieshouse.ordernotification.config.TestConfig;
+import uk.gov.companieshouse.ordernotification.emailsender.NonRetryableFailureException;
+
+@SpringBootTest
+@Import(TestConfig.class)
+@TestPropertySource(locations="classpath:application-stubbed.properties")
+@ActiveProfiles("feature-flags-disabled")
+@ExtendWith(MockitoExtension.class)
+class SummaryEmailDataDirectorTest {
+
+    @Autowired
+    private SummaryEmailDataDirector summaryEmailDataDirector;
+
+    @MockBean
+    private OrderNotificationDataConvertable orderNotificationDataConvertable;
+
+    @Mock
+    private OrdersApi ordersApi;
+
+    @Mock
+    private BaseItemApi certificate;
+
+    @Mock
+    private BaseItemApi certifiedCopy;
+
+    @Mock
+    private BaseItemApi missingImageDelivery;
+
+    @Mock
+    private OrderNotificationEmailData emailData;
+
+    @Test
+    @DisplayName("test maps item kinds to the correct mapper methods")
+    void testMapSuccess() {
+        // given
+        when(certificate.getKind()).thenReturn("item#certificate");
+        when(certifiedCopy.getKind()).thenReturn("item#certified-copy");
+        when(missingImageDelivery.getKind()).thenReturn("item#missing-image-delivery");
+        when(ordersApi.getItems()).thenReturn(Arrays.asList(certificate, certifiedCopy, missingImageDelivery));
+        when(orderNotificationDataConvertable.getEmailData()).thenReturn(emailData);
+
+        // when
+        OrderNotificationEmailData actual = summaryEmailDataDirector.map(ordersApi);
+
+        // then
+        assertEquals(emailData, actual);
+        verify(orderNotificationDataConvertable).mapOrder(ordersApi);
+        verify(orderNotificationDataConvertable).mapCertificate(certificate);
+        verify(orderNotificationDataConvertable).mapCertifiedCopy(certifiedCopy);
+        verify(orderNotificationDataConvertable).mapMissingImageDelivery(missingImageDelivery);
+    }
+
+    @Test
+    @DisplayName("test throws non-retryable exception when handling an unknown item kind")
+    void testMapFailure() {
+        // given
+        when(certificate.getKind()).thenReturn("incorrect-kind");
+        when(ordersApi.getItems()).thenReturn(Collections.singletonList(certificate));
+
+        // when
+        Executable actual = () -> summaryEmailDataDirector.map(ordersApi);
+
+        // then
+        NonRetryableFailureException exception = assertThrows(NonRetryableFailureException.class, actual);
+        assertEquals("Unhandled kind: [incorrect-kind]", exception.getMessage());
+        verify(orderNotificationDataConvertable).mapOrder(ordersApi);
+        verifyNoMoreInteractions(orderNotificationDataConvertable);
+    }
+}


### PR DESCRIPTION
* Delegates mapping logic to converter method depending on item kind
* Converter annotated as prototype scope and interface proxy mode
* as to use separate converter data per call to SummaryEmailDataDirector
* map method.

[GCI-2239](https://companieshouse.atlassian.net/browse/GCI-2239)