### PR TITLE
GCI-2241 Certified document mapping logic

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
@@ -1,13 +1,23 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import java.util.List;
+import java.util.Objects;
+
 public class CertifiedCopy {
     private String id;
-    private String dateFiled;
-    private String type;
-    private String description;
     private String companyNumber;
     private String deliveryMethod;
-    private String fee;
+    private List<FilingHistoryDetailsModel> filingHistoryDetailsModelList;
+
+    public CertifiedCopy(String id,
+            String companyNumber,
+            String deliveryMethod,
+            List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
+        this.id = id;
+        this.companyNumber = companyNumber;
+        this.deliveryMethod = deliveryMethod;
+        this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+    }
 
     public String getId() {
         return id;
@@ -17,36 +27,8 @@ public class CertifiedCopy {
         this.id = id;
     }
 
-    public String getDateFiled() {
-        return dateFiled;
-    }
-
-    public void setDateFiled(String dateFiled) {
-        this.dateFiled = dateFiled;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public String getCompanyNumber() {
         return companyNumber;
-    }
-
-    public void setCompanyNumber(String companyNumber) {
-        this.companyNumber = companyNumber;
     }
 
     public String getDeliveryMethod() {
@@ -57,11 +39,82 @@ public class CertifiedCopy {
         this.deliveryMethod = deliveryMethod;
     }
 
-    public String getFee() {
-        return fee;
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
     }
 
-    public void setFee(String fee) {
-        this.fee = fee;
+    public List<FilingHistoryDetailsModel> getFilingHistoryDetailsModelList() {
+        return filingHistoryDetailsModelList;
+    }
+
+    public void setFilingHistoryDetailsModelList(List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
+        this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+    }
+
+    public static CertifiedCopyBuilder builder() {
+        return new CertifiedCopyBuilder();
+    }
+
+    static class CertifiedCopyBuilder implements Cloneable {
+        private String id;
+        private String companyNumber;
+        private String deliveryMethod;
+        private List<FilingHistoryDetailsModel> filingHistoryDetailsModelList;
+
+        @Override
+        protected CertifiedCopyBuilder clone() {
+            try {
+                return (CertifiedCopyBuilder) super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public CertifiedCopyBuilder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withCompanyNumber(String companyNumber) {
+            this.companyNumber = companyNumber;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withDeliveryMethod(String deliveryMethod) {
+            this.deliveryMethod = deliveryMethod;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withFilingHistoryDetailsModelList(
+                List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
+            this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+            return this;
+        }
+
+        public CertifiedCopy build() {
+            return new CertifiedCopy(id, companyNumber, deliveryMethod,
+                    filingHistoryDetailsModelList);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CertifiedCopyBuilder that = (CertifiedCopyBuilder) o;
+            return Objects.equals(id, that.id) &&
+                    Objects.equals(companyNumber, that.companyNumber) &&
+                    Objects.equals(deliveryMethod, that.deliveryMethod) &&
+                    Objects.equals(filingHistoryDetailsModelList,
+                            that.filingHistoryDetailsModelList);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
@@ -51,6 +51,27 @@ public class CertifiedCopy {
         this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CertifiedCopy that = (CertifiedCopy) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(companyNumber, that.companyNumber) &&
+                Objects.equals(deliveryMethod, that.deliveryMethod) &&
+                Objects.equals(filingHistoryDetailsModelList,
+                        that.filingHistoryDetailsModelList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
+    }
+
     public static CertifiedCopyBuilder builder() {
         return new CertifiedCopyBuilder();
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
@@ -51,27 +51,6 @@ public class CertifiedCopy {
         this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CertifiedCopy that = (CertifiedCopy) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(companyNumber, that.companyNumber) &&
-                Objects.equals(deliveryMethod, that.deliveryMethod) &&
-                Objects.equals(filingHistoryDetailsModelList,
-                        that.filingHistoryDetailsModelList);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
-    }
-
     public static CertifiedCopyBuilder builder() {
         return new CertifiedCopyBuilder();
     }
@@ -137,5 +116,26 @@ public class CertifiedCopy {
         public int hashCode() {
             return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CertifiedCopy that = (CertifiedCopy) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(companyNumber, that.companyNumber) &&
+                Objects.equals(deliveryMethod, that.deliveryMethod) &&
+                Objects.equals(filingHistoryDetailsModelList,
+                        that.filingHistoryDetailsModelList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopy.java
@@ -1,22 +1,25 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
-import java.util.List;
 import java.util.Objects;
 
 public class CertifiedCopy {
     private String id;
     private String companyNumber;
     private String deliveryMethod;
-    private List<FilingHistoryDetailsModel> filingHistoryDetailsModelList;
+    private String dateFiled;
+    private String type;
+    private String description;
+    private String fee;
 
-    public CertifiedCopy(String id,
-            String companyNumber,
-            String deliveryMethod,
-            List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
+    public CertifiedCopy(String id, String companyNumber, String deliveryMethod,
+            String dateFiled, String type, String description, String fee) {
         this.id = id;
         this.companyNumber = companyNumber;
         this.deliveryMethod = deliveryMethod;
-        this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+        this.dateFiled = dateFiled;
+        this.type = type;
+        this.description = description;
+        this.fee = fee;
     }
 
     public String getId() {
@@ -43,12 +46,36 @@ public class CertifiedCopy {
         this.companyNumber = companyNumber;
     }
 
-    public List<FilingHistoryDetailsModel> getFilingHistoryDetailsModelList() {
-        return filingHistoryDetailsModelList;
+    public String getDateFiled() {
+        return dateFiled;
     }
 
-    public void setFilingHistoryDetailsModelList(List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
-        this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+    public void setDateFiled(String dateFiled) {
+        this.dateFiled = dateFiled;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getFee() {
+        return fee;
+    }
+
+    public void setFee(String fee) {
+        this.fee = fee;
     }
 
     public static CertifiedCopyBuilder builder() {
@@ -59,7 +86,10 @@ public class CertifiedCopy {
         private String id;
         private String companyNumber;
         private String deliveryMethod;
-        private List<FilingHistoryDetailsModel> filingHistoryDetailsModelList;
+        private String dateFiled;
+        private String type;
+        private String description;
+        private String fee;
 
         @Override
         protected CertifiedCopyBuilder clone() {
@@ -85,36 +115,29 @@ public class CertifiedCopy {
             return this;
         }
 
-        public CertifiedCopyBuilder withFilingHistoryDetailsModelList(
-                List<FilingHistoryDetailsModel> filingHistoryDetailsModelList) {
-            this.filingHistoryDetailsModelList = filingHistoryDetailsModelList;
+        public CertifiedCopyBuilder withDateFiled(String dateFiled) {
+            this.dateFiled = dateFiled;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CertifiedCopyBuilder withFee(String fee) {
+            this.fee = fee;
             return this;
         }
 
         public CertifiedCopy build() {
             return new CertifiedCopy(id, companyNumber, deliveryMethod,
-                    filingHistoryDetailsModelList);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            CertifiedCopyBuilder that = (CertifiedCopyBuilder) o;
-            return Objects.equals(id, that.id) &&
-                    Objects.equals(companyNumber, that.companyNumber) &&
-                    Objects.equals(deliveryMethod, that.deliveryMethod) &&
-                    Objects.equals(filingHistoryDetailsModelList,
-                            that.filingHistoryDetailsModelList);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
+                    dateFiled, type, description, fee);
         }
     }
 
@@ -130,12 +153,14 @@ public class CertifiedCopy {
         return Objects.equals(id, that.id) &&
                 Objects.equals(companyNumber, that.companyNumber) &&
                 Objects.equals(deliveryMethod, that.deliveryMethod) &&
-                Objects.equals(filingHistoryDetailsModelList,
-                        that.filingHistoryDetailsModelList);
+                Objects.equals(dateFiled, that.dateFiled) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(fee, that.fee);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, companyNumber, deliveryMethod, filingHistoryDetailsModelList);
+        return Objects.hash(id, companyNumber, deliveryMethod, dateFiled, type, description, fee);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapper.java
@@ -1,0 +1,58 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
+import uk.gov.companieshouse.api.model.order.item.CertifiedCopyItemOptionsApi;
+import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+
+public class CertifiedCopyEmailDataMapper {
+    private final DeliveryMethodMapper deliveryMethodMapper;
+    private final FilingHistoryDescriptionProviderService providerService;
+    private EmailConfiguration emailConfiguration;
+
+    public CertifiedCopyEmailDataMapper(DeliveryMethodMapper deliveryMethodMapper,
+            FilingHistoryDescriptionProviderService providerService,
+            EmailConfiguration emailConfiguration) {
+        this.deliveryMethodMapper = deliveryMethodMapper;
+        this.providerService = providerService;
+        this.emailConfiguration = emailConfiguration;
+    }
+
+    CertifiedCopy map(BaseItemApi certifiedDocumentItem) {
+        CertifiedCopyItemOptionsApi itemOptions =
+                (CertifiedCopyItemOptionsApi) certifiedDocumentItem.getItemOptions();
+
+        return CertifiedCopy.builder()
+                .withId(certifiedDocumentItem.getId())
+                .withCompanyNumber(certifiedDocumentItem.getCompanyNumber())
+                .withDeliveryMethod(deliveryMethodMapper.mapDeliveryMethod(
+                        itemOptions.getDeliveryMethod(), itemOptions.getDeliveryTimescale()))
+                .withFilingHistoryDetailsModelList(mapFilingHistoryDocuments(itemOptions))
+                .build();
+    }
+
+    private List<FilingHistoryDetailsModel> mapFilingHistoryDocuments(
+            CertifiedCopyItemOptionsApi itemOptions) {
+        return itemOptions.getFilingHistoryDocuments().stream()
+            .map(filingHistoryDocumentApi -> {
+                FilingHistoryDetailsModel details = new FilingHistoryDetailsModel();
+                details.setFilingHistoryDate(
+                        LocalDate.parse(filingHistoryDocumentApi.getFilingHistoryDate())
+                        .format(DateTimeFormatter.ofPattern(emailConfiguration.getDocument()
+                                .getFilingHistoryDateFormat())));
+                details.setFilingHistoryCost(
+                        "£" + filingHistoryDocumentApi.getFilingHistoryCost());
+                details.setFilingHistoryDescription(
+                        this.providerService.mapFilingHistoryDescription(
+                                filingHistoryDocumentApi.getFilingHistoryDescription(),
+                                filingHistoryDocumentApi.getFilingHistoryDescriptionValues()
+                        )
+                );
+                details.setFilingHistoryType(filingHistoryDocumentApi.getFilingHistoryType());
+                return details;
+            }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapper.java
@@ -26,12 +26,12 @@ public class CertifiedCopyEmailDataMapper {
                 (CertifiedCopyItemOptionsApi) certifiedDocumentItem.getItemOptions();
 
         return CertifiedCopy.builder()
-                .withId(certifiedDocumentItem.getId())
-                .withCompanyNumber(certifiedDocumentItem.getCompanyNumber())
-                .withDeliveryMethod(deliveryMethodMapper.mapDeliveryMethod(
-                        itemOptions.getDeliveryMethod(), itemOptions.getDeliveryTimescale()))
-                .withFilingHistoryDetailsModelList(mapFilingHistoryDocuments(itemOptions))
-                .build();
+            .withId(certifiedDocumentItem.getId())
+            .withCompanyNumber(certifiedDocumentItem.getCompanyNumber())
+            .withDeliveryMethod(deliveryMethodMapper.mapDeliveryMethod(
+                    itemOptions.getDeliveryMethod(), itemOptions.getDeliveryTimescale()))
+            .withFilingHistoryDetailsModelList(mapFilingHistoryDocuments(itemOptions))
+            .build();
     }
 
     private List<FilingHistoryDetailsModel> mapFilingHistoryDocuments(

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapperTest.java
@@ -1,0 +1,209 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
+import uk.gov.companieshouse.api.model.order.item.CertifiedCopyItemOptionsApi;
+import uk.gov.companieshouse.api.model.order.item.DeliveryTimescaleApi;
+import uk.gov.companieshouse.api.model.order.item.FilingHistoryDocumentApi;
+import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+import uk.gov.companieshouse.ordernotification.config.EmailDataConfiguration;
+import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
+
+@ExtendWith(MockitoExtension.class)
+public class CertifiedCopyEmailDataMapperTest {
+    private static final BaseItemBuilder baseCertifiedCopy = baseItemBuilder()
+            .withId(TestConstants.CERTIFIED_COPY_ID)
+            .withCompanyNumber(TestConstants.COMPANY_NUMBER)
+            .withFilingHistoryDocument(getFilingHistoryDocumentApiList());
+
+    private static final CertifiedCopy.CertifiedCopyBuilder mappedBaseCertifiedCopy =
+            CertifiedCopy.builder()
+                .withId(TestConstants.CERTIFIED_COPY_ID)
+                .withCompanyNumber(TestConstants.COMPANY_NUMBER)
+                .withFilingHistoryDetailsModelList(getFilingHistoryDetailsModelList());
+
+    private static final BaseItemBuilder standardDelivery = baseCertifiedCopy.clone()
+            .withDeliveryTimescale(DeliveryTimescaleApi.STANDARD);
+
+    private static final CertifiedCopy.CertifiedCopyBuilder mappedStandardDelivery =
+            mappedBaseCertifiedCopy.clone()
+                .withDeliveryMethod(TestConstants.MAPPED_STANDARD_DELIVERY_TEXT);
+
+    private static final BaseItemBuilder expressDelivery = baseCertifiedCopy.clone()
+            .withDeliveryTimescale(DeliveryTimescaleApi.SAME_DAY);
+
+    private static final CertifiedCopy.CertifiedCopyBuilder mappedExpressDelivery =
+            mappedBaseCertifiedCopy.clone()
+                .withDeliveryMethod(TestConstants.MAPPED_EXPRESS_DELIVERY_TEXT);
+
+    @InjectMocks
+    private CertifiedCopyEmailDataMapper mapper;
+
+    @Mock
+    private DeliveryMethodMapper deliveryMapper;
+
+    @Mock
+    private EmailConfiguration config;
+
+    @Mock
+    private EmailDataConfiguration emailDataConfig;
+
+    @Mock
+    private FilingHistoryDescriptionProviderService providerService;
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getArguments")
+    @DisplayName("Map certified copy item to certified copy model")
+    void testMapCertifiedCopy(String name, ExpectationsBuilder expectationsBuilder) {
+        // given
+        BaseItemApi input = expectationsBuilder.buildBaseItem();
+        CertifiedCopyItemOptionsApi itemOptions = (CertifiedCopyItemOptionsApi) input.getItemOptions();
+        CertifiedCopy expected = expectationsBuilder.buildCertifiedCopy();
+
+        when(deliveryMapper.mapDeliveryMethod(any(), any())).thenReturn(expected.getDeliveryMethod());
+        when(config.getDocument()).thenReturn(emailDataConfig);
+        when(emailDataConfig.getFilingHistoryDateFormat()).thenReturn(TestConstants.EMAIL_DATE_FORMAT);
+        when(providerService.mapFilingHistoryDescription(eq(TestConstants.FILING_HISTORY_DESCRIPTION), any()))
+                .thenReturn(TestConstants.MAPPED_FILING_HISTORY_DESCRIPTION);
+
+        // when
+        CertifiedCopy actual = mapper.map(input);
+
+        // then
+        assertEquals(expected, actual);
+        verify(deliveryMapper).mapDeliveryMethod(itemOptions.getDeliveryMethod(), itemOptions.getDeliveryTimescale());
+        verify(providerService).mapFilingHistoryDescription(TestConstants.FILING_HISTORY_DESCRIPTION, getFilingHistoryDescriptionValues());
+    }
+
+    static Stream<Arguments> getArguments() {
+        return Stream.of(
+                Arguments.of("Map a certified copy with standard delivery option",
+                        expectationsBuilder(standardDelivery, mappedStandardDelivery)),
+                Arguments.of("Map a certified copy with express delivery option",
+                        expectationsBuilder(expressDelivery, mappedExpressDelivery))
+        );
+    }
+
+    static ExpectationsBuilder expectationsBuilder(BaseItemBuilder baseItemBuilder, CertifiedCopy.CertifiedCopyBuilder certifiedCopyBuilder) {
+        return new ExpectationsBuilder(baseItemBuilder, certifiedCopyBuilder);
+    }
+
+    static BaseItemBuilder baseItemBuilder() {
+        return new BaseItemBuilder();
+    }
+
+    static class ExpectationsBuilder {
+        private final BaseItemBuilder baseItemBuilder;
+        private final CertifiedCopy.CertifiedCopyBuilder certifiedCopyBuilder;
+
+        public ExpectationsBuilder(BaseItemBuilder baseItemBuilder, CertifiedCopy.CertifiedCopyBuilder certifiedCopyBuilder) {
+            this.baseItemBuilder = baseItemBuilder;
+            this.certifiedCopyBuilder = certifiedCopyBuilder;
+        }
+
+        public CertifiedCopy buildCertifiedCopy() {
+            return certifiedCopyBuilder.build();
+        }
+
+        public BaseItemApi buildBaseItem() {
+            return baseItemBuilder.build();
+        }
+    }
+
+    static class BaseItemBuilder implements Cloneable {
+        private String id;
+        private String companyNumber;
+        private DeliveryTimescaleApi deliveryTimescale;
+        private List<FilingHistoryDocumentApi> filingHistoryDocumentApis;
+
+        @Override
+        protected BaseItemBuilder clone() {
+            try {
+                return (BaseItemBuilder) super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public BaseItemBuilder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public BaseItemBuilder withCompanyNumber(String companyNumber) {
+            this.companyNumber = companyNumber;
+            return this;
+        }
+
+        public BaseItemBuilder withDeliveryTimescale(DeliveryTimescaleApi deliveryTimescale) {
+            this.deliveryTimescale = deliveryTimescale;
+            return this;
+        }
+
+        public BaseItemBuilder withFilingHistoryDocument(List<FilingHistoryDocumentApi> filingHistoryDocumentApis) {
+            this.filingHistoryDocumentApis = filingHistoryDocumentApis;
+            return this;
+        }
+
+        BaseItemApi build() {
+            BaseItemApi result = new BaseItemApi();
+            CertifiedCopyItemOptionsApi itemOptions = new CertifiedCopyItemOptionsApi();
+            result.setId(id);
+            result.setCompanyNumber(companyNumber);
+            itemOptions.setDeliveryTimescale(deliveryTimescale);
+            itemOptions.setFilingHistoryDocuments(filingHistoryDocumentApis);
+            result.setItemOptions(itemOptions);
+
+            return result;
+        }
+    }
+
+    private static List<FilingHistoryDocumentApi> getFilingHistoryDocumentApiList() {
+        Map<String, Object> filingHistoryDescriptionValues = new HashMap<>();
+        filingHistoryDescriptionValues.put("made_up_date", TestConstants.MADE_UP_DATE);
+
+        FilingHistoryDocumentApi filingHistoryDocument = new FilingHistoryDocumentApi();
+        filingHistoryDocument.setFilingHistoryCost(TestConstants.ORDER_COST);
+        filingHistoryDocument.setFilingHistoryDate(TestConstants.FILING_HISTORY_DATE);
+        filingHistoryDocument.setFilingHistoryType(TestConstants.FILING_HISTORY_TYPE);
+        filingHistoryDocument.setFilingHistoryDescription(TestConstants.FILING_HISTORY_DESCRIPTION);
+        filingHistoryDocument.setFilingHistoryDescriptionValues(getFilingHistoryDescriptionValues());
+
+        return Collections.singletonList(filingHistoryDocument);
+    }
+
+    private static Map<String, Object> getFilingHistoryDescriptionValues() {
+        Map<String, Object> filingHistoryDescriptionValues = new HashMap<>();
+        filingHistoryDescriptionValues.put("made_up_date", TestConstants.MADE_UP_DATE);
+        filingHistoryDescriptionValues.put("key", "value");
+        return filingHistoryDescriptionValues;
+    }
+
+    private static List<FilingHistoryDetailsModel> getFilingHistoryDetailsModelList() {
+        FilingHistoryDetailsModel filingHistoryDetailsModel = new FilingHistoryDetailsModel();
+        filingHistoryDetailsModel.setFilingHistoryCost(TestConstants.ORDER_VIEW);
+        filingHistoryDetailsModel.setFilingHistoryDate(TestConstants.FILING_HISTORY_DATE_VIEW);
+        filingHistoryDetailsModel.setFilingHistoryType(TestConstants.FILING_HISTORY_TYPE);
+        filingHistoryDetailsModel.setFilingHistoryDescription(TestConstants.MAPPED_FILING_HISTORY_DESCRIPTION);
+
+        return Collections.singletonList(filingHistoryDetailsModel);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/CertifiedCopyEmailDataMapperTest.java
@@ -38,7 +38,10 @@ public class CertifiedCopyEmailDataMapperTest {
             CertifiedCopy.builder()
                 .withId(TestConstants.CERTIFIED_COPY_ID)
                 .withCompanyNumber(TestConstants.COMPANY_NUMBER)
-                .withFilingHistoryDetailsModelList(getFilingHistoryDetailsModelList());
+                .withDateFiled(TestConstants.FILING_HISTORY_DATE_VIEW)
+                .withType(TestConstants.FILING_HISTORY_TYPE)
+                .withDescription(TestConstants.MAPPED_FILING_HISTORY_DESCRIPTION)
+                .withFee(TestConstants.ORDER_VIEW);
 
     private static final BaseItemBuilder standardDelivery = baseCertifiedCopy.clone()
             .withDeliveryTimescale(DeliveryTimescaleApi.STANDARD);
@@ -195,15 +198,5 @@ public class CertifiedCopyEmailDataMapperTest {
         filingHistoryDescriptionValues.put("made_up_date", TestConstants.MADE_UP_DATE);
         filingHistoryDescriptionValues.put("key", "value");
         return filingHistoryDescriptionValues;
-    }
-
-    private static List<FilingHistoryDetailsModel> getFilingHistoryDetailsModelList() {
-        FilingHistoryDetailsModel filingHistoryDetailsModel = new FilingHistoryDetailsModel();
-        filingHistoryDetailsModel.setFilingHistoryCost(TestConstants.ORDER_VIEW);
-        filingHistoryDetailsModel.setFilingHistoryDate(TestConstants.FILING_HISTORY_DATE_VIEW);
-        filingHistoryDetailsModel.setFilingHistoryType(TestConstants.FILING_HISTORY_TYPE);
-        filingHistoryDetailsModel.setFilingHistoryDescription(TestConstants.MAPPED_FILING_HISTORY_DESCRIPTION);
-
-        return Collections.singletonList(filingHistoryDetailsModel);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/fixtures/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/fixtures/TestConstants.java
@@ -24,6 +24,10 @@ public final class TestConstants {
     public static final String ORDER_CREATED_AT = "27 July 2021";
     public static final String EMAIL_COPY_EXPRESS_ONLY = "Email only available for express delivery method";
     public static final String DELIVERY_TIMESCALE = "STANDARD";
+    public static final String MAPPED_STANDARD_DELIVERY_TEXT = "Standard delivery (aim to "
+            + "dispatch within 10 working days)";
+    public static final String MAPPED_EXPRESS_DELIVERY_TEXT = "Express (Orders received before 11am "
+            + "will be dispatched the same day. Orders received after 11am will be dispatched the next working day)";
 
     //certificate order constants
     public static final String LIMITED_COMPANY_TYPE = "ltd";
@@ -41,6 +45,7 @@ public final class TestConstants {
     public static final String MESSAGE_TYPE = "message_type";
 
     //document order constants
+    public static final String CERTIFIED_COPY_ID = "CCD-123456-123456";
     public static final String FILING_HISTORY_DATE = "2021-07-28";
     public static final String FILING_HISTORY_DATE_VIEW = "28 July 2021";
     public static final String DELIVERY_METHOD = "Standard delivery (aim to dispatch within 5 working days)";


### PR DESCRIPTION
* Map the correct value for data provided by from BaseItemApi
* Separate private method to map filing history document values
* Add new constants to TestConstants class
* Add equals and hashcode methods to CertifiedCopy

Resolves [GCI-2241 Implement mapping logic for certified copies](https://companieshouse.atlassian.net/browse/GCI-2241) 