### PR TITLE
GCI-2151 Add missing to, subject fields to email model

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class OrderNotificationEmailData {
+    private String to;
+    private String subject;
     private String orderId;
     private List<Certificate> certificates = new ArrayList<>();
     private List<CertifiedCopy> certifiedCopies  = new ArrayList<>();;
@@ -17,6 +19,22 @@ public class OrderNotificationEmailData {
     private boolean hasExpressDelivery;
     private String orderSummaryLink;
     private int dispatchDays;
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
 
     public String getOrderId() {
         return orderId;
@@ -110,6 +128,22 @@ public class OrderNotificationEmailData {
         this.dispatchDays = dispatchDays;
     }
 
+    public boolean isHasStandardDelivery() {
+        return hasStandardDelivery;
+    }
+
+    public void setHasStandardDelivery(boolean hasStandardDelivery) {
+        this.hasStandardDelivery = hasStandardDelivery;
+    }
+
+    public boolean isHasExpressDelivery() {
+        return hasExpressDelivery;
+    }
+
+    public void setHasExpressDelivery(boolean hasExpressDelivery) {
+        this.hasExpressDelivery = hasExpressDelivery;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -118,12 +152,12 @@ public class OrderNotificationEmailData {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        OrderNotificationEmailData emailData = (OrderNotificationEmailData) o;
-        return hasStandardDelivery == emailData.hasStandardDelivery && hasExpressDelivery == emailData.hasExpressDelivery && dispatchDays == emailData.dispatchDays && Objects.equals(orderId, emailData.orderId) && Objects.equals(certificates, emailData.certificates) && Objects.equals(certifiedCopies, emailData.certifiedCopies) && Objects.equals(missingImageDeliveries, emailData.missingImageDeliveries) && Objects.equals(deliveryDetails, emailData.deliveryDetails) && Objects.equals(paymentDetails, emailData.paymentDetails) && Objects.equals(orderSummaryLink, emailData.orderSummaryLink);
+        OrderNotificationEmailData that = (OrderNotificationEmailData) o;
+        return hasStandardDelivery == that.hasStandardDelivery && hasExpressDelivery == that.hasExpressDelivery && dispatchDays == that.dispatchDays && Objects.equals(to, that.to) && Objects.equals(subject, that.subject) && Objects.equals(orderId, that.orderId) && Objects.equals(certificates, that.certificates) && Objects.equals(certifiedCopies, that.certifiedCopies) && Objects.equals(missingImageDeliveries, that.missingImageDeliveries) && Objects.equals(deliveryDetails, that.deliveryDetails) && Objects.equals(paymentDetails, that.paymentDetails) && Objects.equals(orderSummaryLink, that.orderSummaryLink);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(orderId, certificates, certifiedCopies, missingImageDeliveries, deliveryDetails, paymentDetails, hasStandardDelivery, hasExpressDelivery, orderSummaryLink, dispatchDays);
+        return Objects.hash(to, subject, orderId, certificates, certifiedCopies, missingImageDeliveries, deliveryDetails, paymentDetails, hasStandardDelivery, hasExpressDelivery, orderSummaryLink, dispatchDays);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
@@ -3,9 +3,7 @@ package uk.gov.companieshouse.ordernotification.emailsendmodel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.stereotype.Component;
 
-@Component
 public class OrderNotificationEmailData {
     private String to;
     private String subject;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailData.java
@@ -94,22 +94,6 @@ public class OrderNotificationEmailData {
         this.paymentDetails = paymentDetails;
     }
 
-    public boolean hasStandardDelivery() {
-        return hasStandardDelivery;
-    }
-
-    public void hasStandardDelivery(boolean hasStandardDelivery) {
-        this.hasStandardDelivery = hasStandardDelivery;
-    }
-
-    public boolean hasExpressDelivery() {
-        return hasExpressDelivery;
-    }
-
-    public void hasExpressDelivery(boolean hasExpressDelivery) {
-        this.hasExpressDelivery = hasExpressDelivery;
-    }
-
     public String getOrderSummaryLink() {
         return orderSummaryLink;
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+
+@Component
+public class OrderNotificationEmailDataBuilderFactory {
+
+    private final CertificateEmailDataMapper certificateEmailDataMapper;
+    private final CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper;
+    private final MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper;
+    private final EmailConfiguration emailConfiguration;
+
+    public OrderNotificationEmailDataBuilderFactory(CertificateEmailDataMapper certificateEmailDataMapper,
+                                                    CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper,
+                                                    MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper,
+                                                    EmailConfiguration emailConfiguration) {
+        this.certificateEmailDataMapper = certificateEmailDataMapper;
+        this.certifiedCopyEmailDataMapper = certifiedCopyEmailDataMapper;
+        this.missingImageDeliveryEmailDataMapper = missingImageDeliveryEmailDataMapper;
+        this.emailConfiguration = emailConfiguration;
+    }
+
+    OrderNotificationDataConvertable newConverter() {
+        return new OrderNotificationEmailDataConverter(
+                new OrderNotificationEmailData(),
+                this.certificateEmailDataMapper,
+                this.certifiedCopyEmailDataMapper,
+                this.missingImageDeliveryEmailDataMapper,
+                this.emailConfiguration
+        );
+    }
+
+    SummaryEmailDataDirector newDirector(OrderNotificationDataConvertable convertable) {
+        return new SummaryEmailDataDirector(convertable);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
@@ -98,9 +98,9 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
 
     private void mapDeliveryTimescale(DeliveryTimescaleApi deliveryTimescaleApi) {
         if (deliveryTimescaleApi == DeliveryTimescaleApi.STANDARD) {
-            emailData.hasStandardDelivery(true);
+            emailData.setHasStandardDelivery(true);
         } else if (deliveryTimescaleApi == DeliveryTimescaleApi.SAME_DAY){
-            emailData.hasExpressDelivery(true);
+            emailData.setHasExpressDelivery(true);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
@@ -2,10 +2,8 @@ package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
 import java.text.MessageFormat;
 import java.time.format.DateTimeFormatter;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.stereotype.Component;
+import java.util.Objects;
+
 import uk.gov.companieshouse.api.model.order.DeliveryDetailsApi;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
@@ -14,8 +12,6 @@ import uk.gov.companieshouse.api.model.order.item.CertifiedCopyItemOptionsApi;
 import uk.gov.companieshouse.api.model.order.item.DeliveryTimescaleApi;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
 
-@Component
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE, proxyMode = ScopedProxyMode.INTERFACES)
 public class OrderNotificationEmailDataConverter implements OrderNotificationDataConvertable {
 
     private static final String ORDER_SUMMARY_LINK = "%s/orders/%s";
@@ -106,5 +102,22 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
         } else if (deliveryTimescaleApi == DeliveryTimescaleApi.SAME_DAY){
             emailData.hasExpressDelivery(true);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrderNotificationEmailDataConverter that = (OrderNotificationEmailDataConverter) o;
+        return Objects.equals(emailData, that.emailData) && Objects.equals(certificateEmailDataMapper, that.certificateEmailDataMapper) && Objects.equals(certifiedCopyEmailDataMapper, that.certifiedCopyEmailDataMapper) && Objects.equals(missingImageDeliveryEmailDataMapper, that.missingImageDeliveryEmailDataMapper) && Objects.equals(emailConfiguration, that.emailConfiguration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(emailData, certificateEmailDataMapper, certifiedCopyEmailDataMapper, missingImageDeliveryEmailDataMapper, emailConfiguration);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import java.text.MessageFormat;
 import java.time.format.DateTimeFormatter;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -19,11 +20,11 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
 
     private static final String ORDER_SUMMARY_LINK = "%s/orders/%s";
 
-    private OrderNotificationEmailData emailData;
-    private CertificateEmailDataMapper certificateEmailDataMapper;
-    private CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper;
-    private MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper;
-    private EmailConfiguration emailConfiguration;
+    private final OrderNotificationEmailData emailData;
+    private final CertificateEmailDataMapper certificateEmailDataMapper;
+    private final CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper;
+    private final MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper;
+    private final EmailConfiguration emailConfiguration;
 
     public OrderNotificationEmailDataConverter(OrderNotificationEmailData emailData,
             CertificateEmailDataMapper certificateEmailDataMapper,
@@ -45,6 +46,8 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
         mapDeliveryDetails(ordersApi);
         mapPaymentDetails(ordersApi);
         emailData.setDispatchDays(emailConfiguration.getDispatchDays());
+        emailData.setTo(ordersApi.getOrderedBy().getEmail());
+        emailData.setSubject(MessageFormat.format(emailConfiguration.getConfirmationMessage(), ordersApi.getReference()));
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
@@ -18,16 +18,16 @@ public class OrdersApiDetailsMapper {
     private final DateGenerator dateGenerator;
     private final EmailConfiguration config;
     private final ObjectMapper objectMapper;
-    private final SummaryEmailDataDirector director;
+    private final OrderNotificationEmailDataBuilderFactory factory;
 
     public OrdersApiDetailsMapper(DateGenerator dateGenerator,
                                   EmailConfiguration config,
                                   ObjectMapper objectMapper,
-                                  SummaryEmailDataDirector director) {
+                                  OrderNotificationEmailDataBuilderFactory factory) {
         this.dateGenerator = dateGenerator;
         this.config = config;
         this.objectMapper = objectMapper;
-        this.director = director;
+        this.factory = factory;
     }
 
     /**
@@ -38,11 +38,13 @@ public class OrdersApiDetailsMapper {
      * @return EmailSend
      */
     public EmailSend mapToEmailSend(OrdersApiWrappable ordersApiWrappable) {
-        OrderNotificationEmailData emailData = director.map(ordersApiWrappable.getOrdersApi());
+        OrderNotificationDataConvertable converter = factory.newConverter();
+        SummaryEmailDataDirector director = factory.newDirector(converter);
+        director.map(ordersApiWrappable.getOrdersApi());
         try {
             EmailSend emailSend = new EmailSend();
             emailSend.setEmailAddress(config.getSenderAddress());
-            emailSend.setData(objectMapper.writeValueAsString(emailData));
+            emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
             emailSend.setMessageId(config.getMessageId());
             emailSend.setAppId(config.getApplicationId());
             emailSend.setMessageType(config.getMessageType());

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirector.java
@@ -1,11 +1,11 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
 import uk.gov.companieshouse.ordernotification.emailsender.NonRetryableFailureException;
 
-@Component
+import java.util.Objects;
+
 public class SummaryEmailDataDirector {
 
     private final OrderNotificationDataConvertable converter;
@@ -14,7 +14,7 @@ public class SummaryEmailDataDirector {
         this.converter = converter;
     }
 
-    public OrderNotificationEmailData map(OrdersApi ordersApi) {
+    public void map(OrdersApi ordersApi) {
         converter.mapOrder(ordersApi);
         for (BaseItemApi itemApi: ordersApi.getItems()) {
             String kind = itemApi.getKind();
@@ -28,6 +28,22 @@ public class SummaryEmailDataDirector {
                 throw new NonRetryableFailureException(String.format("Unhandled kind: [%s]", kind));
             }
         }
-        return converter.getEmailData();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SummaryEmailDataDirector that = (SummaryEmailDataDirector) o;
+        return Objects.equals(converter, that.converter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(converter);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactoryTest.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderNotificationEmailDataBuilderFactoryTest {
+
+    @InjectMocks
+    private OrderNotificationEmailDataBuilderFactory factory;
+
+    @Mock
+    private CertificateEmailDataMapper certificateEmailDataMapper;
+
+    @Mock
+    private CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper;
+
+    @Mock
+    private MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper;
+
+    @Mock
+    private EmailConfiguration emailConfiguration;
+
+    @Mock
+    private OrderNotificationDataConvertable converter;
+
+    @Test
+    void createNewConverterInstance() {
+        // when
+        OrderNotificationDataConvertable actual = factory.newConverter();
+
+        // then
+        assertEquals(new OrderNotificationEmailDataConverter(new OrderNotificationEmailData(), certificateEmailDataMapper, certifiedCopyEmailDataMapper, missingImageDeliveryEmailDataMapper, emailConfiguration), actual);
+    }
+
+    @Test
+    void createNewDirectorInstance() {
+        // when
+        SummaryEmailDataDirector actual = factory.newDirector(converter);
+
+        // then
+        assertEquals(new SummaryEmailDataDirector(converter), actual);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverterTest.java
@@ -126,7 +126,7 @@ class OrderNotificationEmailDataConverterTest {
 
         // then
         assertTrue(converter.getEmailData().getCertificates().contains(certificate));
-        assertTrue(converter.getEmailData().hasStandardDelivery());
+        assertTrue(converter.getEmailData().isHasStandardDelivery());
         verify(certificateEmailDataMapper).map(certificateApi);
     }
 
@@ -141,7 +141,7 @@ class OrderNotificationEmailDataConverterTest {
 
         // then
         assertTrue(converter.getEmailData().getCertificates().contains(certificate));
-        assertTrue(converter.getEmailData().hasExpressDelivery());
+        assertTrue(converter.getEmailData().isHasExpressDelivery());
         verify(certificateEmailDataMapper).map(certificateApi);
     }
 
@@ -156,7 +156,7 @@ class OrderNotificationEmailDataConverterTest {
 
         // then
         assertTrue(converter.getEmailData().getCertifiedCopies().contains(certifiedCopy));
-        assertTrue(converter.getEmailData().hasStandardDelivery());
+        assertTrue(converter.getEmailData().isHasStandardDelivery());
         verify(certifiedCopyEmailDataMapper).map(certifiedCopyApi);
     }
 
@@ -171,7 +171,7 @@ class OrderNotificationEmailDataConverterTest {
 
         // then
         assertTrue(converter.getEmailData().getCertifiedCopies().contains(certifiedCopy));
-        assertTrue(converter.getEmailData().hasExpressDelivery());
+        assertTrue(converter.getEmailData().isHasExpressDelivery());
         verify(certifiedCopyEmailDataMapper).map(certifiedCopyApi);
     }
 

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.order.ActionedByApi;
 import uk.gov.companieshouse.api.model.order.DeliveryDetailsApi;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.api.model.order.item.CertificateApi;
@@ -71,6 +72,9 @@ class OrderNotificationEmailDataConverterTest {
     @Mock
     private MissingImageDelivery missingImageDelivery;
 
+    @Mock
+    private ActionedByApi orderedBy;
+
     @BeforeEach
     void setup() {
         emailData = new OrderNotificationEmailData();
@@ -95,9 +99,12 @@ class OrderNotificationEmailDataConverterTest {
         when(ordersApi.getPaymentReference()).thenReturn(TestConstants.PAYMENT_REFERENCE);
         when(ordersApi.getOrderedAt()).thenReturn(TestConstants.TEST_DATE);
         when(ordersApi.getTotalOrderCost()).thenReturn(TestConstants.ORDER_COST);
+        when(ordersApi.getOrderedBy()).thenReturn(orderedBy);
+        when(orderedBy.getEmail()).thenReturn(TestConstants.USER_EMAIL);
         when(emailConfiguration.getPaymentDateFormat()).thenReturn(TestConstants.PAYMENT_DATE_FORMAT);
         when(emailConfiguration.getChsUrl()).thenReturn(TestConstants.CHS_URL);
         when(emailConfiguration.getDispatchDays()).thenReturn(10);
+        when(emailConfiguration.getConfirmationMessage()).thenReturn(TestConstants.CONFIRMATION_MESSAGE);
 
         // when
         converter.mapOrder(ordersApi);
@@ -201,6 +208,8 @@ class OrderNotificationEmailDataConverterTest {
                 .withCountry(TestConstants.COUNTRY)
                 .build());
         result.setDispatchDays(10);
+        result.setTo(TestConstants.USER_EMAIL);
+        result.setSubject(TestConstants.CONFIRMATION_MESSAGE_HEAD + TestConstants.ORDER_REFERENCE_NUMBER);
         return result;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirectorTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailsendmodel/SummaryEmailDataDirectorTest.java
@@ -12,28 +12,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.api.model.order.item.BaseItemApi;
-import uk.gov.companieshouse.ordernotification.config.TestConfig;
 import uk.gov.companieshouse.ordernotification.emailsender.NonRetryableFailureException;
 
-@SpringBootTest
-@Import(TestConfig.class)
-@TestPropertySource(locations="classpath:application-stubbed.properties")
 @ExtendWith(MockitoExtension.class)
 class SummaryEmailDataDirectorTest {
 
-    @Autowired
+    @InjectMocks
     private SummaryEmailDataDirector summaryEmailDataDirector;
 
-    @MockBean
+    @Mock
     private OrderNotificationDataConvertable orderNotificationDataConvertable;
 
     @Mock
@@ -59,13 +51,11 @@ class SummaryEmailDataDirectorTest {
         when(certifiedCopy.getKind()).thenReturn("item#certified-copy");
         when(missingImageDelivery.getKind()).thenReturn("item#missing-image-delivery");
         when(ordersApi.getItems()).thenReturn(Arrays.asList(certificate, certifiedCopy, missingImageDelivery));
-        when(orderNotificationDataConvertable.getEmailData()).thenReturn(emailData);
 
         // when
-        OrderNotificationEmailData actual = summaryEmailDataDirector.map(ordersApi);
+        summaryEmailDataDirector.map(ordersApi);
 
         // then
-        assertEquals(emailData, actual);
         verify(orderNotificationDataConvertable).mapOrder(ordersApi);
         verify(orderNotificationDataConvertable).mapCertificate(certificate);
         verify(orderNotificationDataConvertable).mapCertifiedCopy(certifiedCopy);

--- a/src/test/java/uk/gov/companieshouse/ordernotification/fixtures/TestConstants.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/fixtures/TestConstants.java
@@ -61,6 +61,9 @@ public final class TestConstants {
     public static final LocalDateTime TEST_DATE = LocalDateTime.of(2021, 7, 27, 15, 20, 10);
 
     public static final String CHS_URL = "https://find-and-update.company-information.service.gov.uk/";
+    public static final String USER_EMAIL = "demo@ch.gov.uk";
+    public static final String CONFIRMATION_MESSAGE_HEAD = "Confirmation of your order number ";
+    public static final String CONFIRMATION_MESSAGE = CONFIRMATION_MESSAGE_HEAD + "{0}";
 
     private TestConstants(){
     }


### PR DESCRIPTION
* Fields to, subject required by chs-notification-api.
* Fix scoping issue in OrdersApiDetailsMapper causing single
OrderNotificationEmailData object to be persisted across
multiple requests.