### PR TITLE
DCAC-279: Idempotence not supported in our Kafka 0.10 clusters, do not require it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.version>1.8</java.version>
         <log4j.version>2.17.1</log4j.version>
-        <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.6.3</spring-boot-dependencies.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -29,7 +29,6 @@
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <testcontainers.version>1.16.0</testcontainers.version>
         <org.hamcrest.version>2.2</org.hamcrest.version>
-        <kafka-clients.version>2.8.2</kafka-clients.version>
         <sonar.exclusions>
             **/config/ApplicationConfig.java,
             **/config/EmailConfiguration.java,
@@ -166,7 +165,6 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${kafka-clients.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <testcontainers.version>1.16.0</testcontainers.version>
         <org.hamcrest.version>2.2</org.hamcrest.version>
+        <kafka-clients.version>2.8.2</kafka-clients.version>
         <sonar.exclusions>
             **/config/ApplicationConfig.java,
             **/config/EmailConfiguration.java,
@@ -165,6 +166,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
+            <version>${kafka-clients.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
@@ -1,0 +1,88 @@
+package uk.gov.companieshouse.ordernotification.consumer.itemgroupprocessedsend;
+
+import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.ITEM_GROUP_PROCESSED_SEND;
+import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.SAME_PARTITION_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * "Test" class re-purposed to produce
+ * {@link uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend} messages to the
+ * <code>item-group-processed-send</code> topic in Tilt. This is NOT to be run as part of an
+ * automated test suite. It is for manual testing only.
+ */
+@SpringBootTest
+@TestPropertySource(locations = "classpath:item-group-processed-send-in-tilt.properties")
+@Import(ItemGroupProcessedSendInTiltProducer.Config.class)
+@SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
+class ItemGroupProcessedSendInTiltProducer {
+
+    private static final String TOPIC = "item-group-processed-send";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+        "ItemGroupProcessedSendInTiltProducer");
+
+    private static final int MESSAGE_WAIT_TIMEOUT_SECONDS = 10;
+
+    @Configuration
+    static class Config {
+
+        @Bean
+        KafkaProducer<String, ItemGroupProcessedSend> testProducer(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+            final Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.ACKS_CONFIG, "all");
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            return new KafkaProducer<>(
+                config,
+                new StringSerializer(),
+                (topic, data) -> {
+                    try {
+                        return new SerializerFactory().getSpecificRecordSerializer(
+                            ItemGroupProcessedSend.class).toBinary(data); //creates a leading space
+                    } catch (SerializationException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        }
+
+    }
+
+    @Autowired
+    private KafkaProducer<String, ItemGroupProcessedSend> testProducer;
+
+    @SuppressWarnings("squid:S2699") // at least one assertion
+    @Test
+    void produceMessageToTilt() throws InterruptedException, ExecutionException, TimeoutException {
+        final Future<RecordMetadata> future = testProducer.send(new ProducerRecord<>(
+            TOPIC, 0, System.currentTimeMillis(), SAME_PARTITION_KEY, ITEM_GROUP_PROCESSED_SEND));
+        final RecordMetadata result = future.get(MESSAGE_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        final int partition = result.partition();
+        final long offset = result.offset();
+        LOGGER.info("Message " + ITEM_GROUP_PROCESSED_SEND + " delivered to topic " + TOPIC
+            + " on partition " + partition + " with offset " + offset + ".");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
@@ -56,7 +56,6 @@ class ItemGroupProcessedSendInTiltProducer {
             final Map<String, Object> config = new HashMap<>();
             config.put(ProducerConfig.ACKS_CONFIG, "all");
             config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-            config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
             return new KafkaProducer<>(
                 config,
                 new StringSerializer(),

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendInTiltProducer.java
@@ -56,6 +56,7 @@ class ItemGroupProcessedSendInTiltProducer {
             final Map<String, Object> config = new HashMap<>();
             config.put(ProducerConfig.ACKS_CONFIG, "all");
             config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
             return new KafkaProducer<>(
                 config,
                 new StringSerializer(),

--- a/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.ordernotification.messageproducer;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.kafka.exceptions.ProducerConfigException;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.producer.Acks;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.ordernotification.consumer.PartitionOffset;
+import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
+import uk.gov.companieshouse.ordernotification.logging.LoggingUtilsConfiguration;
+
+/**
+ * "Test" class re-purposed to produce {@link EmailSend} messages to the
+ * <code>email-send</code> topic in Tilt. This is NOT to be run as part of an
+ * automated test suite. It is for manual testing only.
+ */
+@SpringBootTest
+@TestPropertySource(locations = "classpath:email-send-in-tilt.properties")
+@Import({MessageProducer.class, MessageFactory.class, KafkaProducer.class,
+    LoggingUtilsConfiguration.class, EmailSendInTiltProducer.Config.class})
+@SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
+class EmailSendInTiltProducer {
+
+    private static final String TOPIC = "email-send";
+
+    private static final EmailSend EMAIL_SEND;
+
+    static {
+        EmailSend emailSend = new EmailSend();
+        emailSend.setAppId("App Id");
+        emailSend.setData("Message content");
+        emailSend.setEmailAddress("someone@example.com");
+        emailSend.setMessageId("Message Id");
+        emailSend.setMessageType("Message type");
+        emailSend.setCreatedAt("2020-08-25T09:27:09.519+01:00");
+        EMAIL_SEND = emailSend;
+    }
+
+    @Configuration
+    static class Config {
+
+        @Bean
+        public Logger logger() {
+            return LoggerFactory.getLogger(
+                "EmailSendInTiltProducer");
+        }
+
+        @Bean
+        public CHKafkaProducer chKafkaProducer(ProducerConfig producerConfig) {
+            return new CHKafkaProducer(producerConfig);
+        }
+
+        @Bean
+        public ProducerConfig producerConfig(
+            @Value("${spring.kafka.bootstrap-servers}") String brokerAddresses) {
+            final ProducerConfig config = new ProducerConfig();
+            if (brokerAddresses != null && !brokerAddresses.isEmpty()) {
+                config.setBrokerAddresses(brokerAddresses.split(","));
+            } else {
+                throw new ProducerConfigException(
+                    "Broker addresses for kafka broker missing, check if environment variable KAFKA_BROKER_ADDR is configured. "
+                        +
+                        "[Hint: The property 'kafka.broker.addresses' uses the value of this environment variable in live environments "
+                        +
+                        "and that of 'spring.embedded.kafka.brokers' property in test.]");
+            }
+            config.setRoundRobinPartitioner(true);
+            config.setAcks(Acks.WAIT_FOR_ALL);
+            config.setRetries(10);
+            return config;
+        }
+
+        @Bean
+        public PartitionOffset errorRecoveryOffset() {
+            return new PartitionOffset();
+        }
+
+        @Bean
+        SerializerFactory serializerFactory() {
+            return new SerializerFactory();
+        }
+
+    }
+
+    @Autowired
+    private MessageProducer messageProducer;
+
+    @SuppressWarnings("squid:S2699") // at least one assertion
+    @Test
+    void produceMessageToTilt()
+        throws InterruptedException, ExecutionException, TimeoutException, SerializationException {
+        messageProducer.sendMessage(EMAIL_SEND, "order URI", TOPIC);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
@@ -78,7 +78,7 @@ class EmailSendInTiltProducer {
                         "and that of 'spring.embedded.kafka.brokers' property in test.]");
             }
             config.setRoundRobinPartitioner(true);
-            config.setAcks(Acks.WAIT_FOR_ALL);
+            config.setAcks(Acks.WAIT_FOR_LOCAL);
             config.setRetries(10);
             return config;
         }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
@@ -40,7 +40,7 @@ class EmailSendInTiltProducer {
 
     static {
         EmailSend emailSend = new EmailSend();
-        emailSend.setAppId("App Id");
+        emailSend.setAppId("EmailSendInTiltProducer");
         emailSend.setData("Message content");
         emailSend.setEmailAddress("someone@example.com");
         emailSend.setMessageId("Message Id");

--- a/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/messageproducer/EmailSendInTiltProducer.java
@@ -78,7 +78,7 @@ class EmailSendInTiltProducer {
                         "and that of 'spring.embedded.kafka.brokers' property in test.]");
             }
             config.setRoundRobinPartitioner(true);
-            config.setAcks(Acks.WAIT_FOR_LOCAL);
+            config.setAcks(Acks.WAIT_FOR_ALL);
             config.setRetries(10);
             return config;
         }

--- a/src/test/resources/email-send-in-tilt.properties
+++ b/src/test/resources/email-send-in-tilt.properties
@@ -1,2 +1,2 @@
-spring.kafka.bootstrap-servers = localhost:29092
+spring.kafka.bootstrap-servers = kafka-broker1-cidev.development.aws.internal:9092
 kafkaProducer.producerTimeout = 60

--- a/src/test/resources/email-send-in-tilt.properties
+++ b/src/test/resources/email-send-in-tilt.properties
@@ -1,0 +1,2 @@
+spring.kafka.bootstrap-servers = localhost:29092
+kafkaProducer.producerTimeout = 60

--- a/src/test/resources/email-send-in-tilt.properties
+++ b/src/test/resources/email-send-in-tilt.properties
@@ -1,2 +1,2 @@
-spring.kafka.bootstrap-servers = kafka-broker1-cidev.development.aws.internal:9092
+spring.kafka.bootstrap-servers = localhost:29092
 kafkaProducer.producerTimeout = 60

--- a/src/test/resources/item-group-processed-send-in-tilt.properties
+++ b/src/test/resources/item-group-processed-send-in-tilt.properties
@@ -1,0 +1,1 @@
+spring.kafka.bootstrap-servers=localhost:29092

--- a/src/test/resources/item-group-processed-send-in-tilt.properties
+++ b/src/test/resources/item-group-processed-send-in-tilt.properties
@@ -1,1 +1,1 @@
-spring.kafka.bootstrap-servers=kafka-broker1-cidev.development.aws.internal:9092
+spring.kafka.bootstrap-servers = localhost:29092

--- a/src/test/resources/item-group-processed-send-in-tilt.properties
+++ b/src/test/resources/item-group-processed-send-in-tilt.properties
@@ -1,1 +1,1 @@
-spring.kafka.bootstrap-servers=localhost:29092
+spring.kafka.bootstrap-servers=kafka-broker1-cidev.development.aws.internal:9092


### PR DESCRIPTION
* Changes previously made for DCAC-279 resulted in the `order-notification-sender` made it unable produce any messages to the Kafka 0.10 cluster in `cidev`.
* Any attempt to produce a message would result in the following error message:
`"message":"Publishing message to retry topic","error":"java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.UnsupportedVersionException: Attempting to use idempotence with a broker which does not support the required message format (v2). The broker must be version 0.11 or later."}} `
* "Manual" tests were added to be able to reproduce the error producing messages to the `cidev` cluster, and various approaches were explored, including explicitly disabling the requirement for idempotence.
* However, as @jsimons1989 pointed out in [this discussion](https://companieshouse.slack.com/archives/C02TZ3RCGG5/p1701777667663479), the reason why it appeared necessary to deconfigure idempotence to avoid this problem was that the work had upgraded the version of Spring Boot involved, bringing in a later version of `kafka-clients` that defaulted the configuration of idempotence.
* Hence, the significant change now presented in this PR is the downgrade of the version of Spring Boot used from `2.7.18` to `2.6.3`. This brings in a version of `kafka-clients` that does not configure idempotence by default, whilst also supporting newer Spring Boot features for DCAC-279.
  