### PR TITLE
DCAC-295: Produce item ready email email-send messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <junit-jupiter-engine-version>5.8.2</junit-jupiter-engine-version>
-        <private-api-sdk-java.version>2.0.188</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.280</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <testcontainers.version>1.16.0</testcontainers.version>
         <org.hamcrest.version>2.2</org.hamcrest.version>

--- a/src/main/java/uk/gov/companieshouse/ordernotification/config/EmailConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/config/EmailConfiguration.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 @PropertySource("classpath:application.properties")
 @ConfigurationProperties(prefix = "email")
 @Component
-public class EmailConfiguration {
+public class EmailConfiguration implements MessageTypeConfigProvider {
     private String dateFormat;
     private String senderAddress;
     private String paymentDateFormat;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/config/ItemReadyEmailConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/config/ItemReadyEmailConfiguration.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.ordernotification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Configuration
+@PropertySource("classpath:application.properties")
+@ConfigurationProperties(prefix = "item-ready-email")
+@Component
+public class ItemReadyEmailConfiguration {
+
+    private String messageId;
+    private String messageType;
+    private String subject;
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
+
+    public String getMessageType() {
+        return messageType;
+    }
+
+    public void setMessageType(String messageType) {
+        this.messageType = messageType;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/config/ItemReadyEmailConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/config/ItemReadyEmailConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @PropertySource("classpath:application.properties")
 @ConfigurationProperties(prefix = "item-ready-email")
 @Component
-public class ItemReadyEmailConfiguration {
+public class ItemReadyEmailConfiguration implements MessageTypeConfigProvider {
 
     private String messageId;
     private String messageType;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/config/MessageTypeConfigProvider.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/config/MessageTypeConfigProvider.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.ordernotification.config;
+
+public interface MessageTypeConfigProvider {
+
+    String getMessageId();
+    String getMessageType();
+
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSender.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSender.java
@@ -23,7 +23,6 @@ public class ItemGroupProcessedSendEmailSender implements ItemGroupProcessedSend
     public void handleMessage(Message<ItemGroupProcessedSend> message) {
         final ItemGroupProcessedSend payload = message.getPayload();
         logger.info("processing item-group-processed-send message: " + payload, getLogMap(payload));
-        // TODO DCAC-295 Do we need to create an event class here?
         applicationEventPublisher.publishEvent(payload);
     }
 

--- a/src/main/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSender.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSender.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.ordernotification.consumer.itemgroupprocessedsend;
 
 import static uk.gov.companieshouse.ordernotification.logging.LoggingUtils.getLogMap;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
@@ -11,16 +12,19 @@ import uk.gov.companieshouse.logging.Logger;
 public class ItemGroupProcessedSendEmailSender implements ItemGroupProcessedSendHandler {
 
     private final Logger logger;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
-    public ItemGroupProcessedSendEmailSender(Logger logger) {
+    public ItemGroupProcessedSendEmailSender(Logger logger,
+        ApplicationEventPublisher applicationEventPublisher) {
         this.logger = logger;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     public void handleMessage(Message<ItemGroupProcessedSend> message) {
         final ItemGroupProcessedSend payload = message.getPayload();
         logger.info("processing item-group-processed-send message: " + payload, getLogMap(payload));
-
-        // TODO DCAC-295: Send the relevant information onwards via the email-send topic.
+        // TODO DCAC-295 Do we need to create an event class here?
+        applicationEventPublisher.publishEvent(payload);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
@@ -17,7 +17,7 @@ import uk.gov.companieshouse.ordernotification.orders.service.OrdersResponseExce
  * <ol>
  *     <li>handles item ready notification</li>
  *     <li>retrieves the order (data) from the Orders API</li>
- *     <li>sends a certificate or certified copy order confirmation via the CHS Email Sender</li>
+ *     <li>sends a certificate or certified copy order confirmation via the CHS Email Sender.</li>
  * </ol>
  */
 @Service
@@ -38,7 +38,7 @@ public class OrderResourceItemReadyNotificationEnricher {
 
     /**
      * Enriches an item ready notification with an order resource fetched from the Orders API, and
-     * with item ready information
+     * with item ready information.
      *
      * @param orderUri  the order responsible for triggering the notification
      * @param itemReadyNotification the incoming item ready notification

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.ordernotification.emailmodel;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.emailsendmodel.MappingException;
 import uk.gov.companieshouse.ordernotification.emailsendmodel.OrdersApiDetailsMapper;
@@ -14,21 +15,20 @@ import uk.gov.companieshouse.ordernotification.orders.service.OrdersResponseExce
 /**
  * This service does the following:
  * <ol>
- *     <li>handles order received notification</li>
+ *     <li>handles item ready notification</li>
  *     <li>retrieves the order (data) from the Orders API</li>
- *     <li>sends a certificate or certified copy order confirmation via the CHS Email Sender OR</li>
- *     <li>sends a MID item message to the CHD Order Consumer</li>
+ *     <li>sends a certificate or certified copy order confirmation via the CHS Email Sender</li>
  * </ol>
  */
 @Service
-public class OrderResourceOrderNotificationEnricher implements OrderNotificationEnrichable {
+public class OrderResourceItemReadyNotificationEnricher {
 
     private final OrderRetrievable orderRetrievable;
     private final LoggingUtils loggingUtils;
     private final OrdersApiDetailsMapper ordersApiMapper;
 
     @Autowired
-    public OrderResourceOrderNotificationEnricher(OrderRetrievable orderRetrievable,
+    public OrderResourceItemReadyNotificationEnricher(OrderRetrievable orderRetrievable,
         LoggingUtils loggingUtils,
         OrdersApiDetailsMapper ordersApiMapper) {
         this.orderRetrievable = orderRetrievable;
@@ -37,21 +37,24 @@ public class OrderResourceOrderNotificationEnricher implements OrderNotification
     }
 
     /**
-     * Enriches an order received notification with an order resource fetched from the Orders API.
+     * Enriches an item ready notification with an order resource fetched from the Orders API, and
+     * with item ready information
      *
-     * @param orderUri the order responsible for triggering the notification
+     * @param orderUri  the order responsible for triggering the notification
+     * @param itemReady the incoming item ready notification
      */
-    public EmailSend enrich(final String orderUri) throws OrdersResponseException {
+    public EmailSend enrich(final String orderUri, final ItemGroupProcessedSend itemReady)
+        throws OrdersResponseException {
         Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order",
             orderUri);
         OrdersApiWrappable order = orderRetrievable.getOrderData(orderUri);
-        loggingUtils.getLogger().debug("Mapping order", logArgs);
+        loggingUtils.getLogger().debug("Mapping order and item ready notification", logArgs);
         try {
-            return ordersApiMapper.mapToEmailSend(order);
+            return ordersApiMapper.mapToEmailSend(order, itemReady);
         } catch (IllegalArgumentException | MappingException e) {
-            loggingUtils.getLogger().error("Failed to map order resource", e, logArgs);
+            loggingUtils.getLogger()
+                .error("Failed to map order and item ready notification", e, logArgs);
             throw e;
         }
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceItemReadyNotificationEnricher.java
@@ -41,16 +41,16 @@ public class OrderResourceItemReadyNotificationEnricher {
      * with item ready information
      *
      * @param orderUri  the order responsible for triggering the notification
-     * @param itemReady the incoming item ready notification
+     * @param itemReadyNotification the incoming item ready notification
      */
-    public EmailSend enrich(final String orderUri, final ItemGroupProcessedSend itemReady)
+    public EmailSend enrich(final String orderUri, final ItemGroupProcessedSend itemReadyNotification)
         throws OrdersResponseException {
         Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order",
             orderUri);
         OrdersApiWrappable order = orderRetrievable.getOrderData(orderUri);
         loggingUtils.getLogger().debug("Mapping order and item ready notification", logArgs);
         try {
-            return ordersApiMapper.mapToEmailSend(order, itemReady);
+            return ordersApiMapper.mapToEmailSend(order, itemReadyNotification);
         } catch (IllegalArgumentException | MappingException e) {
             loggingUtils.getLogger()
                 .error("Failed to map order and item ready notification", e, logArgs);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceOrderNotificationEnricher.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceOrderNotificationEnricher.java
@@ -30,8 +30,8 @@ public class OrderResourceOrderNotificationEnricher implements OrderNotification
 
     @Autowired
     public OrderResourceOrderNotificationEnricher(OrderRetrievable orderRetrievable,
-                                                  LoggingUtils loggingUtils,
-                                                  OrdersApiDetailsMapper ordersApiMapper) {
+        LoggingUtils loggingUtils,
+        OrdersApiDetailsMapper ordersApiMapper) {
         this.orderRetrievable = orderRetrievable;
         this.loggingUtils = loggingUtils;
         this.ordersApiMapper = ordersApiMapper;
@@ -43,7 +43,8 @@ public class OrderResourceOrderNotificationEnricher implements OrderNotification
      * @param orderUri the order responsible for triggering the notification
      */
     public EmailSend enrich(final String orderUri) throws OrdersResponseException {
-        Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order", orderUri);
+        Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order",
+            orderUri);
         OrdersApiWrappable order = orderRetrievable.getOrderData(orderUri);
         loggingUtils.getLogger().debug("Mapping order", logArgs);
         try {
@@ -58,11 +59,13 @@ public class OrderResourceOrderNotificationEnricher implements OrderNotification
      * Enriches an item ready notification with an order resource fetched from the Orders API, and
      * with item ready information
      *
-     * @param orderUri the order responsible for triggering the notification
+     * @param orderUri  the order responsible for triggering the notification
      * @param itemReady the incoming item ready notification
      */
-    public EmailSend enrich(final String orderUri, final ItemGroupProcessedSend itemReady) throws OrdersResponseException {
-        Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order", orderUri);
+    public EmailSend enrich(final String orderUri, final ItemGroupProcessedSend itemReady)
+        throws OrdersResponseException {
+        Map<String, Object> logArgs = loggingUtils.logWithOrderUri("Fetching resource for order",
+            orderUri);
         OrdersApiWrappable order = orderRetrievable.getOrderData(orderUri);
         loggingUtils.getLogger().debug("Mapping order", logArgs);
         try {

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
@@ -58,8 +58,7 @@ public class EmailSendService implements ApplicationEventPublisherAware {
     }
 
     /**
-     * Handles an incoming {@link SendItemReadyEmailEvent} by sending a message containing email data. If an error
-     * occurs when publishing the message then the error handler will be notified.
+     * Handles an incoming {@link SendItemReadyEmailEvent} by sending a message containing email data.
      *
      * @param event A {@link SendItemReadyEmailEvent} object containing item ready email data
      * @throws NonRetryableFailureException if a serialization error occurs or the producer is interrupted

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
@@ -62,10 +62,12 @@ public class EmailSendService implements ApplicationEventPublisherAware {
     }
 
     /**
-     * Handles an incoming {@link SendItemReadyEmailEvent} by sending a message containing email data.
+     * Handles an incoming {@link SendItemReadyEmailEvent} by sending a message containing email
+     * data for an item ready email.
      *
      * @param event A {@link SendItemReadyEmailEvent} object containing item ready email data
-     * @throws NonRetryableFailureException if a serialization error occurs or the producer is interrupted
+     * @throws NonRetryableFailureException if a serialization error occurs
+     * @throws InterruptedException if the producer is interrupted
      */
     @EventListener
     public void handleEvent(final SendItemReadyEmailEvent event) throws InterruptedException {

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/EmailSendService.java
@@ -10,7 +10,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.logging.util.DataMap;
-import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
 import uk.gov.companieshouse.ordernotification.messageproducer.MessageProducer;
 
@@ -76,8 +75,7 @@ public class EmailSendService implements ApplicationEventPublisherAware {
         } catch (ExecutionException | TimeoutException e) {
             final String error = "Error sending email data to Kafka";
             loggingUtils.getLogger().error(error, e, getLogMap(event));
-            // TODO DCAC-295 Dedicated exception type?
-            throw new RetryableErrorException(error, e);
+            throw new SendItemReadyEmailException(error, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             final String error = "Interrupted";

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailEvent.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailEvent.java
@@ -3,13 +3,15 @@ package uk.gov.companieshouse.ordernotification.emailsender;
 /**
  * Raised when an enriched item ready notification is ready to be published.
  */
-public class SendItemReadyEmailEvent /* TODO DCAC-295 Does this help? *implements OrderIdentifiable*/ {
+public class SendItemReadyEmailEvent {
 
     private final String orderURI;
+    private final String itemId;
     private final EmailSend emailModel;
 
-    public SendItemReadyEmailEvent(String orderURI, EmailSend emailModel) {
+    public SendItemReadyEmailEvent(String orderURI, String itemId, EmailSend emailModel) {
         this.orderURI = orderURI;
+        this.itemId = itemId;
         this.emailModel = emailModel;
     }
 
@@ -21,4 +23,7 @@ public class SendItemReadyEmailEvent /* TODO DCAC-295 Does this help? *implement
         return emailModel;
     }
 
+    public String getItemId() {
+        return itemId;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailEvent.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailEvent.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.ordernotification.emailsender;
+
+/**
+ * Raised when an enriched item ready notification is ready to be published.
+ */
+public class SendItemReadyEmailEvent /* TODO DCAC-295 Does this help? *implements OrderIdentifiable*/ {
+
+    private final String orderURI;
+    private final EmailSend emailModel;
+
+    public SendItemReadyEmailEvent(String orderURI, EmailSend emailModel) {
+        this.orderURI = orderURI;
+        this.emailModel = emailModel;
+    }
+
+    public String getOrderURI() {
+        return orderURI;
+    }
+
+    public EmailSend getEmailModel() {
+        return emailModel;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailException.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsender/SendItemReadyEmailException.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.ordernotification.emailsender;
+
+import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
+
+/**
+ * Raised if a retryable error occurs when sending an item ready <code>email-send</code> message.
+ */
+public class SendItemReadyEmailException extends RetryableErrorException {
+    public SendItemReadyEmailException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailData.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+@SuppressWarnings("squid:S2160") // Subclasses that add fields should override "equals". Not used.
 public class ItemReadyNotificationEmailData extends OrderNotificationEmailData {
 
     private String orderNumber;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailData.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+public class ItemReadyNotificationEmailData extends OrderNotificationEmailData {
+
+    private String orderNumber;
+    private String itemId;
+    private String digitalDocumentLocation;
+
+    private String groupItem;
+
+    public String getOrderNumber() {
+        return orderNumber;
+    }
+
+    public void setOrderNumber(String orderNumber) {
+        this.orderNumber = orderNumber;
+    }
+
+    public String getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(String itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getDigitalDocumentLocation() {
+        return digitalDocumentLocation;
+    }
+
+    public void setDigitalDocumentLocation(String digitalDocumentLocation) {
+        this.digitalDocumentLocation = digitalDocumentLocation;
+    }
+
+    public String getGroupItem() {
+        return groupItem;
+    }
+
+    public void setGroupItem(String groupItem) {
+        this.groupItem = groupItem;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
 import uk.gov.companieshouse.ordernotification.config.ItemReadyEmailConfiguration;
 
+@SuppressWarnings("squid:S2160") // Subclasses that add fields should override "equals". Not used.
 public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEmailDataConverter {
 
     private final ItemGroupProcessedSend itemReadyNotification;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
@@ -1,21 +1,26 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
+import java.text.MessageFormat;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+import uk.gov.companieshouse.ordernotification.config.ItemReadyEmailConfiguration;
 
 public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEmailDataConverter {
 
     private final ItemGroupProcessedSend itemReadyNotification;
+    private final ItemReadyEmailConfiguration itemReadyConfig;
 
     public ItemReadyNotificationEmailDataConverter(OrderNotificationEmailData emailData,
         CertificateEmailDataMapper certificateEmailDataMapper,
         CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper,
         MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper,
         EmailConfiguration emailConfiguration,
+        ItemReadyEmailConfiguration itemReadyConfig,
         ItemGroupProcessedSend itemReadyNotification) {
         super(emailData, certificateEmailDataMapper, certifiedCopyEmailDataMapper,
             missingImageDeliveryEmailDataMapper, emailConfiguration);
+        this.itemReadyConfig = itemReadyConfig;
         this.itemReadyNotification = itemReadyNotification;
     }
 
@@ -27,6 +32,13 @@ public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEm
         emailData.setOrderNumber(itemReadyNotification.getOrderNumber());
         emailData.setGroupItem(itemReadyNotification.getGroupItem());
         emailData.setItemId(itemReadyNotification.getItem().getId());
-        emailData.setDigitalDocumentLocation(itemReadyNotification.getItem().getDigitalDocumentLocation());
+        emailData.setDigitalDocumentLocation(
+            itemReadyNotification.getItem().getDigitalDocumentLocation());
+    }
+
+    @Override
+    protected String buildSubject(final OrdersApi ordersApi) {
+        return MessageFormat.format(itemReadyConfig.getSubject(),
+            itemReadyNotification.getItem().getId(), ordersApi.getReference());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.ordernotification.emailsendmodel;
+
+import uk.gov.companieshouse.api.model.order.OrdersApi;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+
+public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEmailDataConverter {
+
+    private final ItemGroupProcessedSend itemReadyNotification;
+
+    public ItemReadyNotificationEmailDataConverter(OrderNotificationEmailData emailData,
+        CertificateEmailDataMapper certificateEmailDataMapper,
+        CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper,
+        MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper,
+        EmailConfiguration emailConfiguration,
+        ItemGroupProcessedSend itemReadyNotification) {
+        super(emailData, certificateEmailDataMapper, certifiedCopyEmailDataMapper,
+            missingImageDeliveryEmailDataMapper, emailConfiguration);
+        this.itemReadyNotification = itemReadyNotification;
+    }
+
+    @Override
+    public void mapOrder(OrdersApi ordersApi) {
+        super.mapOrder(ordersApi);
+        final ItemReadyNotificationEmailData emailData =
+            (ItemReadyNotificationEmailData) getEmailData();
+        emailData.setOrderNumber(itemReadyNotification.getOrderNumber());
+        emailData.setGroupItem(itemReadyNotification.getGroupItem());
+        emailData.setItemId(itemReadyNotification.getItem().getId());
+        emailData.setDigitalDocumentLocation(itemReadyNotification.getItem().getDigitalDocumentLocation());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/ItemReadyNotificationEmailDataConverter.java
@@ -9,18 +9,18 @@ import uk.gov.companieshouse.ordernotification.config.ItemReadyEmailConfiguratio
 public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEmailDataConverter {
 
     private final ItemGroupProcessedSend itemReadyNotification;
-    private final ItemReadyEmailConfiguration itemReadyConfig;
+    private final ItemReadyEmailConfiguration itemReadyEmailConfig;
 
     public ItemReadyNotificationEmailDataConverter(OrderNotificationEmailData emailData,
         CertificateEmailDataMapper certificateEmailDataMapper,
         CertifiedCopyEmailDataMapper certifiedCopyEmailDataMapper,
         MissingImageDeliveryEmailDataMapper missingImageDeliveryEmailDataMapper,
         EmailConfiguration emailConfiguration,
-        ItemReadyEmailConfiguration itemReadyConfig,
+        ItemReadyEmailConfiguration itemReadyEmailConfig,
         ItemGroupProcessedSend itemReadyNotification) {
         super(emailData, certificateEmailDataMapper, certifiedCopyEmailDataMapper,
             missingImageDeliveryEmailDataMapper, emailConfiguration);
-        this.itemReadyConfig = itemReadyConfig;
+        this.itemReadyEmailConfig = itemReadyEmailConfig;
         this.itemReadyNotification = itemReadyNotification;
     }
 
@@ -38,7 +38,7 @@ public class ItemReadyNotificationEmailDataConverter extends OrderNotificationEm
 
     @Override
     protected String buildSubject(final OrdersApi ordersApi) {
-        return MessageFormat.format(itemReadyConfig.getSubject(),
+        return MessageFormat.format(itemReadyEmailConfig.getSubject(),
             itemReadyNotification.getItem().getId(), ordersApi.getReference());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.ordernotification.emailsendmodel;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
+import uk.gov.companieshouse.ordernotification.config.ItemReadyEmailConfiguration;
 
 @Component
 public class OrderNotificationEmailDataBuilderFactory {
@@ -32,13 +33,15 @@ public class OrderNotificationEmailDataBuilderFactory {
         );
     }
 
-    OrderNotificationDataConvertable newConverter(final ItemGroupProcessedSend itemReadyNotification) {
+    OrderNotificationDataConvertable newConverter(final ItemGroupProcessedSend itemReadyNotification,
+        final ItemReadyEmailConfiguration itemReadyConfig) {
         return new ItemReadyNotificationEmailDataConverter(
             new ItemReadyNotificationEmailData(),
             this.certificateEmailDataMapper,
             this.certifiedCopyEmailDataMapper,
             this.missingImageDeliveryEmailDataMapper,
             this.emailConfiguration,
+            itemReadyConfig,
             itemReadyNotification
         );
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
@@ -34,14 +34,14 @@ public class OrderNotificationEmailDataBuilderFactory {
     }
 
     OrderNotificationDataConvertable newConverter(final ItemGroupProcessedSend itemReadyNotification,
-        final ItemReadyEmailConfiguration itemReadyConfig) {
+        final ItemReadyEmailConfiguration itemReadyEmailConfig) {
         return new ItemReadyNotificationEmailDataConverter(
             new ItemReadyNotificationEmailData(),
             this.certificateEmailDataMapper,
             this.certifiedCopyEmailDataMapper,
             this.missingImageDeliveryEmailDataMapper,
             this.emailConfiguration,
-            itemReadyConfig,
+            itemReadyEmailConfig,
             itemReadyNotification
         );
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataBuilderFactory.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.ordernotification.emailsendmodel;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
 
 @Component
@@ -28,6 +29,17 @@ public class OrderNotificationEmailDataBuilderFactory {
                 this.certifiedCopyEmailDataMapper,
                 this.missingImageDeliveryEmailDataMapper,
                 this.emailConfiguration
+        );
+    }
+
+    OrderNotificationDataConvertable newConverter(final ItemGroupProcessedSend itemReadyNotification) {
+        return new ItemReadyNotificationEmailDataConverter(
+            new ItemReadyNotificationEmailData(),
+            this.certificateEmailDataMapper,
+            this.certifiedCopyEmailDataMapper,
+            this.missingImageDeliveryEmailDataMapper,
+            this.emailConfiguration,
+            itemReadyNotification
         );
     }
 

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrderNotificationEmailDataConverter.java
@@ -43,7 +43,7 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
         mapPaymentDetails(ordersApi);
         emailData.setDispatchDays(emailConfiguration.getDispatchDays());
         emailData.setTo(ordersApi.getOrderedBy().getEmail());
-        emailData.setSubject(MessageFormat.format(emailConfiguration.getConfirmationMessage(), ordersApi.getReference()));
+        emailData.setSubject(buildSubject(ordersApi));
     }
 
     @Override
@@ -63,6 +63,10 @@ public class OrderNotificationEmailDataConverter implements OrderNotificationDat
     @Override
     public void mapMissingImageDelivery(BaseItemApi missingImageDeliveryApi) {
         emailData.addMissingImageDelivery(missingImageDeliveryEmailDataMapper.map(missingImageDeliveryApi));
+    }
+
+    protected String buildSubject(final OrdersApi ordersApi) {
+        return MessageFormat.format(emailConfiguration.getConfirmationMessage(), ordersApi.getReference());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
@@ -19,18 +19,18 @@ public class OrdersApiDetailsMapper {
 
     private final DateGenerator dateGenerator;
     private final EmailConfiguration config;
-    private final ItemReadyEmailConfiguration itemReadyConfig;
+    private final ItemReadyEmailConfiguration itemReadyEmailConfig;
     private final ObjectMapper objectMapper;
     private final OrderNotificationEmailDataBuilderFactory factory;
 
     public OrdersApiDetailsMapper(DateGenerator dateGenerator,
         EmailConfiguration config,
-        ItemReadyEmailConfiguration itemReadyConfig,
+        ItemReadyEmailConfiguration itemReadyEmailConfig,
         ObjectMapper objectMapper,
         OrderNotificationEmailDataBuilderFactory factory) {
         this.dateGenerator = dateGenerator;
         this.config = config;
-        this.itemReadyConfig = itemReadyConfig;
+        this.itemReadyEmailConfig = itemReadyEmailConfig;
         this.objectMapper = objectMapper;
         this.factory = factory;
     }
@@ -72,16 +72,17 @@ public class OrdersApiDetailsMapper {
      */
     public EmailSend mapToEmailSend(final OrdersApiWrappable ordersApiWrappable, final
     ItemGroupProcessedSend itemReadyNotification) {
-        OrderNotificationDataConvertable converter = factory.newConverter(itemReadyNotification, itemReadyConfig);
+        OrderNotificationDataConvertable converter = factory.newConverter(itemReadyNotification,
+            itemReadyEmailConfig);
         SummaryEmailDataDirector director = factory.newDirector(converter);
         director.map(ordersApiWrappable.getOrdersApi());
         try {
             EmailSend emailSend = new EmailSend();
             emailSend.setEmailAddress(config.getSenderAddress());
             emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
-            emailSend.setMessageId(itemReadyConfig.getMessageId());
+            emailSend.setMessageId(itemReadyEmailConfig.getMessageId());
             emailSend.setAppId(config.getApplicationId());
-            emailSend.setMessageType(itemReadyConfig.getMessageType());
+            emailSend.setMessageType(itemReadyEmailConfig.getMessageType());
             emailSend.setCreatedAt(dateGenerator.generate()
                 .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
             return emailSend;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.model.order.OrdersApi;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
 import uk.gov.companieshouse.ordernotification.config.ItemReadyEmailConfiguration;
+import uk.gov.companieshouse.ordernotification.config.MessageTypeConfigProvider;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.orders.service.OrdersApiWrappable;
 
@@ -44,20 +45,12 @@ public class OrdersApiDetailsMapper {
      */
     public EmailSend mapToEmailSend(OrdersApiWrappable ordersApiWrappable) {
         OrderNotificationDataConvertable converter = factory.newConverter();
-        SummaryEmailDataDirector director = factory.newDirector(converter);
-        director.map(ordersApiWrappable.getOrdersApi());
+        mapDirector(ordersApiWrappable, converter);
         try {
-            EmailSend emailSend = new EmailSend();
-            emailSend.setEmailAddress(config.getSenderAddress());
-            emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
-            emailSend.setMessageId(config.getMessageId());
-            emailSend.setAppId(config.getApplicationId());
-            emailSend.setMessageType(config.getMessageType());
-            emailSend.setCreatedAt(dateGenerator.generate()
-                    .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
-            return emailSend;
+            return buildEmail(converter, config);
         } catch (JsonProcessingException e) {
-            throw new MappingException("Failed to map order: " + ordersApiWrappable.getOrdersApi().getReference(), e);
+            throw new MappingException(
+                "Failed to map order: " + ordersApiWrappable.getOrdersApi().getReference(), e);
         }
     }
 
@@ -66,7 +59,7 @@ public class OrdersApiDetailsMapper {
      * then builds an EmailSend object from the emailData, the email configuration properties and
      * the incoming item ready notification.
      *
-     * @param ordersApiWrappable A wrapper interface for an OrdersApi object
+     * @param ordersApiWrappable    A wrapper interface for an OrdersApi object
      * @param itemReadyNotification the incoming item ready notification
      * @return EmailSend
      */
@@ -74,20 +67,33 @@ public class OrdersApiDetailsMapper {
     ItemGroupProcessedSend itemReadyNotification) {
         OrderNotificationDataConvertable converter = factory.newConverter(itemReadyNotification,
             itemReadyEmailConfig);
+        mapDirector(ordersApiWrappable, converter);
+        try {
+            return buildEmail(converter, itemReadyEmailConfig);
+        } catch (JsonProcessingException e) {
+            throw new MappingException("Failed to map order and item ready notification: "
+                + ordersApiWrappable.getOrdersApi().getReference() + ", "
+                + itemReadyNotification.getItem().getId(), e);
+        }
+    }
+
+    private EmailSend buildEmail(final OrderNotificationDataConvertable converter,
+        final MessageTypeConfigProvider messageTypeConfigProvider)
+        throws JsonProcessingException {
+        EmailSend emailSend = new EmailSend();
+        emailSend.setEmailAddress(config.getSenderAddress());
+        emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
+        emailSend.setMessageId(messageTypeConfigProvider.getMessageId());
+        emailSend.setAppId(config.getApplicationId());
+        emailSend.setMessageType(messageTypeConfigProvider.getMessageType());
+        emailSend.setCreatedAt(dateGenerator.generate()
+            .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
+        return emailSend;
+    }
+
+    private void mapDirector(final OrdersApiWrappable ordersApiWrappable,
+        final OrderNotificationDataConvertable converter) {
         SummaryEmailDataDirector director = factory.newDirector(converter);
         director.map(ordersApiWrappable.getOrdersApi());
-        try {
-            EmailSend emailSend = new EmailSend();
-            emailSend.setEmailAddress(config.getSenderAddress());
-            emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
-            emailSend.setMessageId(itemReadyEmailConfig.getMessageId());
-            emailSend.setAppId(config.getApplicationId());
-            emailSend.setMessageType(itemReadyEmailConfig.getMessageType());
-            emailSend.setCreatedAt(dateGenerator.generate()
-                .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
-            return emailSend;
-        } catch (JsonProcessingException e) {
-            throw new MappingException("Failed to map order: " + ordersApiWrappable.getOrdersApi().getReference(), e);
-        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
@@ -67,12 +67,12 @@ public class OrdersApiDetailsMapper {
      * the incoming item ready notification.
      *
      * @param ordersApiWrappable A wrapper interface for an OrdersApi object
-     * @param itemReady the incoming item ready notification
+     * @param itemReadyNotification the incoming item ready notification
      * @return EmailSend
      */
     public EmailSend mapToEmailSend(final OrdersApiWrappable ordersApiWrappable, final
-    ItemGroupProcessedSend itemReady) {
-        OrderNotificationDataConvertable converter = factory.newConverter(itemReady, itemReadyConfig);
+    ItemGroupProcessedSend itemReadyNotification) {
+        OrderNotificationDataConvertable converter = factory.newConverter(itemReadyNotification, itemReadyConfig);
         SummaryEmailDataDirector director = factory.newDirector(converter);
         director.map(ordersApiWrappable.getOrdersApi());
         try {

--- a/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/emailsendmodel/OrdersApiDetailsMapper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.order.OrdersApi;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.EmailConfiguration;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.orders.service.OrdersApiWrappable;
@@ -50,6 +51,35 @@ public class OrdersApiDetailsMapper {
             emailSend.setMessageType(config.getMessageType());
             emailSend.setCreatedAt(dateGenerator.generate()
                     .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
+            return emailSend;
+        } catch (JsonProcessingException e) {
+            throw new MappingException("Failed to map order: " + ordersApiWrappable.getOrdersApi().getReference(), e);
+        }
+    }
+
+    /**
+     * Delegates mapping of ordersApiWrappable to OrderNotificationEmailData to the director and
+     * then builds an EmailSend object from the emailData, the email configuration properties and
+     * the incoming item ready notification.
+     *
+     * @param ordersApiWrappable A wrapper interface for an OrdersApi object
+     * @param itemReady the incoming item ready notification
+     * @return EmailSend
+     */
+    public EmailSend mapToEmailSend(final OrdersApiWrappable ordersApiWrappable, final
+    ItemGroupProcessedSend itemReady) {
+        OrderNotificationDataConvertable converter = factory.newConverter(itemReady);
+        SummaryEmailDataDirector director = factory.newDirector(converter);
+        director.map(ordersApiWrappable.getOrdersApi());
+        try {
+            EmailSend emailSend = new EmailSend();
+            emailSend.setEmailAddress(config.getSenderAddress());
+            emailSend.setData(objectMapper.writeValueAsString(converter.getEmailData()));
+            emailSend.setMessageId(config.getMessageId());
+            emailSend.setAppId(config.getApplicationId());
+            emailSend.setMessageType(config.getMessageType());
+            emailSend.setCreatedAt(dateGenerator.generate()
+                .format(DateTimeFormatter.ofPattern(config.getDateFormat())));
             return emailSend;
         } catch (JsonProcessingException e) {
             throw new MappingException("Failed to map order: " + ordersApiWrappable.getOrdersApi().getReference(), e);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.ordernotification.itemstatusupdatenotificationsender;
+
+import java.util.Map;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
+import uk.gov.companieshouse.ordernotification.emailmodel.OrderNotificationEnrichable;
+import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
+import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
+import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
+
+/**
+ * Handles an order notification by enriching it with data fetched from the orders API.
+ */
+@Service
+public class ItemGroupProcessedSendSenderService {
+
+    private final OrderNotificationEnrichable orderEnricher;
+    private final LoggingUtils loggingUtils;
+    // TODO DCAC-295 Do we need an application event publisher here?
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public ItemGroupProcessedSendSenderService(OrderNotificationEnrichable orderEnricher, LoggingUtils loggingUtils,
+        ApplicationEventPublisher applicationEventPublisher) {
+        this.orderEnricher = orderEnricher;
+        this.loggingUtils = loggingUtils;
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    /**
+     * Handles an item group item status update notification by enriching it with data
+     * fetched from the orders API. If an error occurs when enriching the notification then a
+     * failure event will be published.
+     *
+     * @param itemGroupProcessedSendEvent The ItemGroupProcessedSend message being processed.
+     */
+    @EventListener
+    public void handleEvent(ItemGroupProcessedSend itemGroupProcessedSendEvent) {
+        Map<String, Object> loggerArgs = loggingUtils.createLogMap();
+        final String orderUri = "/orders/" + itemGroupProcessedSendEvent.getOrderNumber();
+        loggingUtils.logIfNotNull(loggerArgs, LoggingUtils.ORDER_URI, orderUri);
+        try {
+            final EmailSend emailSend = orderEnricher.enrich(orderUri);
+            loggingUtils.getLogger().debug("Successfully enriched item group item status update; notifying email sender", loggerArgs);
+            applicationEventPublisher.publishEvent(new SendEmailEvent(orderUri, /* TODO DCAC-295 Refactor? */0, emailSend));
+
+        } catch (RetryableErrorException e) {
+            loggingUtils.getLogger().error("Failed to enrich item group item status update", e, loggerArgs);
+            // TODO DCAC-295 Hopefully we don't need this - InvalidMessageRouter will ensure retries take place?
+            // applicationEventPublisher.publishEvent(new OrderEnrichmentFailedEvent(itemGroupProcessedSendEvent));
+            throw e;
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -47,8 +47,7 @@ public class ItemGroupProcessedSendSenderService {
                 "Successfully enriched item group item status update; notifying email sender",
                 loggerArgs);
             applicationEventPublisher.publishEvent(
-                new SendEmailEvent(orderUri, /* TODO DCAC-295 Refactor? */0, emailSend));
-
+                new SendEmailEvent(orderUri, 0, emailSend));
         } catch (RetryableErrorException e) {
             loggingUtils.getLogger()
                 .error("Failed to enrich item group item status update", e, loggerArgs);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -6,7 +6,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
-import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceOrderNotificationEnricher;
+import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceItemReadyNotificationEnricher;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
@@ -17,12 +17,12 @@ import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
 @Service
 public class ItemGroupProcessedSendSenderService {
 
-    // TODO DCAC-295 This by-passes the OrderNotificationEnrichable contract.
-    private final OrderResourceOrderNotificationEnricher orderEnricher;
+    private final OrderResourceItemReadyNotificationEnricher orderEnricher;
     private final LoggingUtils loggingUtils;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public ItemGroupProcessedSendSenderService(OrderResourceOrderNotificationEnricher orderEnricher, LoggingUtils loggingUtils,
+    public ItemGroupProcessedSendSenderService(
+        OrderResourceItemReadyNotificationEnricher orderEnricher, LoggingUtils loggingUtils,
         ApplicationEventPublisher applicationEventPublisher) {
         this.orderEnricher = orderEnricher;
         this.loggingUtils = loggingUtils;
@@ -30,9 +30,9 @@ public class ItemGroupProcessedSendSenderService {
     }
 
     /**
-     * Handles an item group item status update notification by enriching it with data
-     * fetched from the orders API. If an error occurs when enriching the notification then a
-     * failure event will be published.
+     * Handles an item group item status update notification by enriching it with data fetched from
+     * the orders API. If an error occurs when enriching the notification then a failure event will
+     * be published.
      *
      * @param itemGroupProcessedSendEvent The ItemGroupProcessedSend message being processed.
      */
@@ -43,11 +43,15 @@ public class ItemGroupProcessedSendSenderService {
         loggingUtils.logIfNotNull(loggerArgs, LoggingUtils.ORDER_URI, orderUri);
         try {
             final EmailSend emailSend = orderEnricher.enrich(orderUri, itemGroupProcessedSendEvent);
-            loggingUtils.getLogger().debug("Successfully enriched item group item status update; notifying email sender", loggerArgs);
-            applicationEventPublisher.publishEvent(new SendEmailEvent(orderUri, /* TODO DCAC-295 Refactor? */0, emailSend));
+            loggingUtils.getLogger().debug(
+                "Successfully enriched item group item status update; notifying email sender",
+                loggerArgs);
+            applicationEventPublisher.publishEvent(
+                new SendEmailEvent(orderUri, /* TODO DCAC-295 Refactor? */0, emailSend));
 
         } catch (RetryableErrorException e) {
-            loggingUtils.getLogger().error("Failed to enrich item group item status update", e, loggerArgs);
+            loggingUtils.getLogger()
+                .error("Failed to enrich item group item status update", e, loggerArgs);
             // TODO DCAC-295 Hopefully we don't need this - InvalidMessageRouter will ensure retries take place?
             // applicationEventPublisher.publishEvent(new OrderEnrichmentFailedEvent(itemGroupProcessedSendEvent));
             throw e;

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -8,7 +8,7 @@ import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
 import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceItemReadyNotificationEnricher;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
-import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
+import uk.gov.companieshouse.ordernotification.emailsender.SendItemReadyEmailEvent;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
 
 /**
@@ -46,7 +46,7 @@ public class ItemGroupProcessedSendSenderService {
                 "Successfully enriched item group item status update; notifying email sender",
                 loggerArgs);
             applicationEventPublisher.publishEvent(
-                new SendEmailEvent(orderUri, 0, emailSend));
+                new SendItemReadyEmailEvent(orderUri, emailSend));
         } catch (RetryableErrorException e) {
             loggingUtils.getLogger()
                 .error("Failed to enrich item group item status update", e, loggerArgs);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -20,7 +20,6 @@ public class ItemGroupProcessedSendSenderService {
     // TODO DCAC-295 This by-passes the OrderNotificationEnrichable contract.
     private final OrderResourceOrderNotificationEnricher orderEnricher;
     private final LoggingUtils loggingUtils;
-    // TODO DCAC-295 Do we need an application event publisher here?
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public ItemGroupProcessedSendSenderService(OrderResourceOrderNotificationEnricher orderEnricher, LoggingUtils loggingUtils,

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.ordernotification.itemstatusupdatenotificationsender;
 
+import static uk.gov.companieshouse.ordernotification.logging.LoggingUtils.getLogMap;
+
 import java.util.Map;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
@@ -37,7 +39,7 @@ public class ItemGroupProcessedSendSenderService {
      */
     @EventListener
     public void handleEvent(ItemGroupProcessedSend itemReadyNotification) {
-        Map<String, Object> loggerArgs = loggingUtils.createLogMap();
+        final Map<String, Object> loggerArgs = getLogMap(itemReadyNotification);
         final String orderUri = "/orders/" + itemReadyNotification.getOrderNumber();
         loggingUtils.logIfNotNull(loggerArgs, LoggingUtils.ORDER_URI, orderUri);
         try {
@@ -46,7 +48,8 @@ public class ItemGroupProcessedSendSenderService {
                 "Successfully enriched item group item status update; notifying email sender",
                 loggerArgs);
             applicationEventPublisher.publishEvent(
-                new SendItemReadyEmailEvent(orderUri, emailSend));
+                new SendItemReadyEmailEvent(orderUri, itemReadyNotification.getItem().getId(),
+                    emailSend));
         } catch (RetryableErrorException e) {
             loggingUtils.getLogger()
                 .error("Failed to enrich item group item status update", e, loggerArgs);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -52,8 +52,6 @@ public class ItemGroupProcessedSendSenderService {
         } catch (RetryableErrorException e) {
             loggingUtils.getLogger()
                 .error("Failed to enrich item group item status update", e, loggerArgs);
-            // TODO DCAC-295 Hopefully we don't need this - InvalidMessageRouter will ensure retries take place?
-            // applicationEventPublisher.publishEvent(new OrderEnrichmentFailedEvent(itemGroupProcessedSendEvent));
             throw e;
         }
     }

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -31,18 +31,17 @@ public class ItemGroupProcessedSendSenderService {
 
     /**
      * Handles an item group item status update notification by enriching it with data fetched from
-     * the orders API. If an error occurs when enriching the notification then a failure event will
-     * be published.
+     * the orders API.
      *
-     * @param itemGroupProcessedSendEvent The ItemGroupProcessedSend message being processed.
+     * @param itemReadyNotification The ItemGroupProcessedSend message being processed.
      */
     @EventListener
-    public void handleEvent(ItemGroupProcessedSend itemGroupProcessedSendEvent) {
+    public void handleEvent(ItemGroupProcessedSend itemReadyNotification) {
         Map<String, Object> loggerArgs = loggingUtils.createLogMap();
-        final String orderUri = "/orders/" + itemGroupProcessedSendEvent.getOrderNumber();
+        final String orderUri = "/orders/" + itemReadyNotification.getOrderNumber();
         loggingUtils.logIfNotNull(loggerArgs, LoggingUtils.ORDER_URI, orderUri);
         try {
-            final EmailSend emailSend = orderEnricher.enrich(orderUri, itemGroupProcessedSendEvent);
+            final EmailSend emailSend = orderEnricher.enrich(orderUri, itemReadyNotification);
             loggingUtils.getLogger().debug(
                 "Successfully enriched item group item status update; notifying email sender",
                 loggerArgs);

--- a/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
+++ b/src/main/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderService.java
@@ -6,23 +6,24 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
-import uk.gov.companieshouse.ordernotification.emailmodel.OrderNotificationEnrichable;
+import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceOrderNotificationEnricher;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
 
 /**
- * Handles an order notification by enriching it with data fetched from the orders API.
+ * Handles an item ready notification by enriching it with data fetched from the orders API.
  */
 @Service
 public class ItemGroupProcessedSendSenderService {
 
-    private final OrderNotificationEnrichable orderEnricher;
+    // TODO DCAC-295 This by-passes the OrderNotificationEnrichable contract.
+    private final OrderResourceOrderNotificationEnricher orderEnricher;
     private final LoggingUtils loggingUtils;
     // TODO DCAC-295 Do we need an application event publisher here?
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public ItemGroupProcessedSendSenderService(OrderNotificationEnrichable orderEnricher, LoggingUtils loggingUtils,
+    public ItemGroupProcessedSendSenderService(OrderResourceOrderNotificationEnricher orderEnricher, LoggingUtils loggingUtils,
         ApplicationEventPublisher applicationEventPublisher) {
         this.orderEnricher = orderEnricher;
         this.loggingUtils = loggingUtils;
@@ -42,7 +43,7 @@ public class ItemGroupProcessedSendSenderService {
         final String orderUri = "/orders/" + itemGroupProcessedSendEvent.getOrderNumber();
         loggingUtils.logIfNotNull(loggerArgs, LoggingUtils.ORDER_URI, orderUri);
         try {
-            final EmailSend emailSend = orderEnricher.enrich(orderUri);
+            final EmailSend emailSend = orderEnricher.enrich(orderUri, itemGroupProcessedSendEvent);
             loggingUtils.getLogger().debug("Successfully enriched item group item status update; notifying email sender", loggerArgs);
             applicationEventPublisher.publishEvent(new SendEmailEvent(orderUri, /* TODO DCAC-295 Refactor? */0, emailSend));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,5 +38,9 @@ email.messageType = order_notification_sender_summary
 email.filingHistoryDateFormat = dd MMM yyyy
 email.chsUrl = ${CHS_URL}
 
+item-ready-email.messageId = digital_item_ready
+item-ready-email.messageType = digital_item_ready
+item-ready-email.subject = Your digital item {0} from order {1} is ready
+
 kafkaProducer.producerTimeout = ${KAFKA_PRODUCER_TIMEOUT}
 maximum.retries = ${MAXIMUM_RETRIES}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/config/EmailSendSendTestConfig.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/config/EmailSendSendTestConfig.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.ordernotification.config;
+
+import consumer.deserialization.AvroDeserializer;
+import consumer.serialization.AvroSerializer;
+import email.email_send;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+import uk.gov.companieshouse.ordernotification.consumer.MessageDeserialiser;
+import uk.gov.companieshouse.ordernotification.consumer.itemgroupprocessedsend.ItemGroupProcessedSendConsumerAspect;
+import uk.gov.companieshouse.orders.OrderReceived;
+
+@TestConfiguration
+public class EmailSendSendTestConfig {
+
+    @Bean
+    KafkaConsumer<String, email_send> emailSendConsumer(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers, EmbeddedKafkaBroker embeddedKafkaBroker, KafkaTopics kafkaTopics) {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(bootstrapServers, UUID.randomUUID().toString(), Boolean.toString(true));
+        KafkaConsumer<String, email_send> kafkaConsumer = new KafkaConsumer<>(props,
+                new StringDeserializer(),
+                new MessageDeserialiser<>(email_send.class));
+
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(kafkaConsumer, kafkaTopics.getEmailSend());
+        return kafkaConsumer;
+    }
+
+    @Bean
+    KafkaProducer<String, OrderReceived> orderReceivedProducer(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        return createProducer(bootstrapServers, OrderReceived.class);
+    }
+
+    private <T extends SpecificRecord> KafkaProducer<String, T> createProducer(String bootstrapServers, Class<T> type) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaProducer<>(config, new StringSerializer(), (topic, data) -> {
+            try {
+                return new SerializerFactory().getSpecificRecordSerializer(type).toBinary(data); //creates a leading space
+            } catch (SerializationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Bean
+    @Scope("prototype")
+    KafkaConsumer<String, email_send> myConsumer(@Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MessageDeserialiser.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, ""+new Random().nextInt());
+        return new KafkaConsumer<>(props, new StringDeserializer(), new MessageDeserialiser<>(email_send.class));
+    }
+
+    @Bean
+    KafkaProducer<String, ItemGroupProcessedSend> itemGroupProcessedSendProducer(
+        @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        return createProducer(bootstrapServers, ItemGroupProcessedSend.class);
+    }
+
+    @Bean
+    KafkaConsumer<String, ItemGroupProcessedSend> testConsumer(
+        @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, AvroSerializer.class);
+        properties.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        properties.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, AvroDeserializer.class);
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        return new KafkaConsumer<>(
+            properties,
+            new StringDeserializer(),
+            new AvroDeserializer<>(ItemGroupProcessedSend.class));
+    }
+
+    @Bean
+    CountDownLatch latch(@Value("${steps}") int steps) {
+        return new CountDownLatch(steps);
+    }
+
+    @Bean
+    ItemGroupProcessedSendConsumerAspect itemGroupProcessedSendConsumerAspect(CountDownLatch latch) {
+        return new ItemGroupProcessedSendConsumerAspect(latch);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/config/TestConfig.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/config/TestConfig.java
@@ -14,6 +14,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
@@ -94,8 +95,9 @@ public class TestConfig {
 
     @Bean
     @Primary
-    public ItemGroupProcessedSendHandler getItemGroupProcessedSendHandler(Logger logger) {
-        return new ItemGroupProcessedSendEmailSender(logger);
+    public ItemGroupProcessedSendHandler getItemGroupProcessedSendHandler(Logger logger,
+        ApplicationEventPublisher applicationEventPublisher) {
+        return new ItemGroupProcessedSendEmailSender(logger, applicationEventPublisher);
     }
 
 

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
@@ -193,12 +193,12 @@ class ItemGroupProcessedSendConsumerEmailSendExceptionTest {
         testProducer.send(new ProducerRecord<>(
             inboundTopic, 0, System.currentTimeMillis(), SAME_PARTITION_KEY,
             ITEM_GROUP_PROCESSED_SEND));
-        if (!latch.await(30L, TimeUnit.SECONDS)) {
+        if (!latch.await(15L, TimeUnit.SECONDS)) {
             fail("Timed out waiting for latch");
         }
 
         // then
-        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 30000L, 6);
+        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 15000L, 6);
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic), is(1));
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-retry"), is(3));
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-error"), is(1));
@@ -231,12 +231,12 @@ class ItemGroupProcessedSendConsumerEmailSendExceptionTest {
         testProducer.send(new ProducerRecord<>(
             inboundTopic, 0, System.currentTimeMillis(), SAME_PARTITION_KEY,
             ITEM_GROUP_PROCESSED_SEND));
-        if (!latch.await(30L, TimeUnit.SECONDS)) {
+        if (!latch.await(15L, TimeUnit.SECONDS)) {
             fail("Timed out waiting for latch");
         }
 
         // then
-        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 30000L, 6);
+        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 15000L, 2);
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic), is(1));
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-retry"), is(0));
         assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-error"), is(0));

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -165,7 +164,6 @@ class ItemGroupProcessedSendConsumerEmailSendExceptionTest {
         verifyExceptionInEmailSendIsNotRetried(SerializationException.class);
     }
 
-    @Disabled("DCAC-295 Why does this test fail?")
     @Test
     void testInterruptedExceptionInEmailSendIsNotRetried()
         throws InterruptedException, SerializationException, ExecutionException, TimeoutException, IOException {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerEmailSendExceptionTest.java
@@ -1,0 +1,252 @@
+package uk.gov.companieshouse.ordernotification.consumer.itemgroupprocessedsend;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static uk.gov.companieshouse.ordernotification.TestUtils.noOfRecordsForTopic;
+import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.ITEM_GROUP_PROCESSED_SEND;
+import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.SAME_PARTITION_KEY;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.kafka.exceptions.SerializationException;
+import uk.gov.companieshouse.ordernotification.config.EmailSendSendTestConfig;
+import uk.gov.companieshouse.ordernotification.config.TestEnvironmentSetupHelper;
+import uk.gov.companieshouse.ordernotification.emailsender.EmailSendService;
+import uk.gov.companieshouse.ordernotification.emailsender.SendItemReadyEmailEvent;
+import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
+import uk.gov.companieshouse.ordernotification.messageproducer.MessageProducer;
+
+/**
+ * These tests verify that exceptions originated in
+ * {@link EmailSendService#handleEvent(SendItemReadyEmailEvent)} are handled correctly and either
+ * result in the processing of the incoming {@link ItemGroupProcessedSend}
+ * being retried up to the maximum configured number of retries, or not, as the case
+ * may be.
+ */
+@SpringBootTest
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@EmbeddedKafka(
+    topics = {"${kafka.topics.item-group-processed-send}",
+        "${kafka.topics.item-group-processed-send}-retry",
+        "${kafka.topics.item-group-processed-send}-error",
+        "${kafka.topics.item-group-processed-send}-invalid"},
+    controlledShutdown = true,
+    partitions = 1
+)
+@TestPropertySource(locations = "classpath:application-main-retryable.properties")
+@Import(EmailSendSendTestConfig.class)
+class ItemGroupProcessedSendConsumerEmailSendExceptionTest {
+
+    private static MockServerContainer container;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired
+    private KafkaConsumer<String, ItemGroupProcessedSend> testConsumer;
+
+    @Autowired
+    private KafkaProducer<String, ItemGroupProcessedSend> testProducer;
+
+    private MockServerClient client;
+
+    @Autowired
+    private CountDownLatch latch;
+
+    @Autowired
+    @Value("${kafka.topics.item-group-processed-send}")
+    private String inboundTopic;
+
+    @Autowired
+    @Value("${kafka.topics.email-send}")
+    private String outboundTopic;
+
+    @SpyBean
+    private ItemGroupProcessedSendHandler itemGroupProcessedSendHandler;
+
+    @MockBean // TODO DCAC-295 SpyBean or MockBean?
+    private MessageProducer messageProducer;
+
+    @Captor
+    private ArgumentCaptor<Message<ItemGroupProcessedSend>> messageCaptor;
+
+    @BeforeAll
+    static void before() {
+        container = new MockServerContainer(DockerImageName.parse(
+            "jamesdbloom/mockserver:mockserver-5.5.4"));
+        container.start();
+        TestEnvironmentSetupHelper.setEnvironmentVariable("API_URL",
+            "http://" + container.getHost() + ":" + container.getServerPort());
+        TestEnvironmentSetupHelper.setEnvironmentVariable("CHS_API_KEY", "123");
+        TestEnvironmentSetupHelper.setEnvironmentVariable("PAYMENTS_API_URL",
+            "http://" + container.getHost() + ":" + container.getServerPort());
+    }
+
+    @AfterAll
+    static void after() {
+        container.stop();
+    }
+
+    @BeforeEach
+    void setup() {
+        client = new MockServerClient(container.getHost(), container.getServerPort());
+        latch = new CountDownLatch(1);
+        ItemGroupProcessedSendKafkaConsumerAspect.setEventLatch(latch);
+    }
+
+    @AfterEach
+    void teardown() {
+        client.reset();
+    }
+
+    @Test
+    void testTimeoutExceptionInEmailSendIsRetried()
+        throws InterruptedException, SerializationException, ExecutionException, TimeoutException, IOException {
+        verifyExceptionInEmailSendIsRetried(TimeoutException.class);
+    }
+
+    @Test
+    void testExecutionExceptionInEmailSendIsRetried()
+        throws InterruptedException, SerializationException, ExecutionException, TimeoutException, IOException {
+        verifyExceptionInEmailSendIsRetried(ExecutionException.class);
+    }
+
+    @Test
+    void testSerializationExceptionInEmailSendIsNotRetried()
+        throws InterruptedException, SerializationException, ExecutionException, TimeoutException, IOException {
+        verifyExceptionInEmailSendIsNotRetried(SerializationException.class);
+    }
+
+    @Disabled("DCAC-295 Why does this test fail?")
+    @Test
+    void testInterruptedExceptionInEmailSendIsNotRetried()
+        throws InterruptedException, SerializationException, ExecutionException, TimeoutException, IOException {
+        verifyExceptionInEmailSendIsNotRetried(InterruptedException.class);
+    }
+
+    private void verifyExceptionInEmailSendIsRetried(final Class<? extends Exception> exceptionClass)
+        throws IOException, SerializationException, ExecutionException, InterruptedException, TimeoutException {
+
+        // given
+        client.when(request()
+                .withPath(TestConstants.ORDER_NOTIFICATION_REFERENCE)
+                .withMethod(HttpMethod.GET.toString()))
+            .respond(response()
+                .withStatusCode(HttpStatus.OK.value())
+                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .withBody(JsonBody.json(IOUtils.resourceToString(
+                    "/fixtures/digital-certified-copy.json",
+                    StandardCharsets.UTF_8))));
+        embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
+        doThrow(exceptionClass).when(messageProducer)
+            .sendMessage(any(GenericRecord.class), anyString(), eq(outboundTopic));
+
+        // when
+        testProducer.send(new ProducerRecord<>(
+            inboundTopic, 0, System.currentTimeMillis(), SAME_PARTITION_KEY,
+            ITEM_GROUP_PROCESSED_SEND));
+        if (!latch.await(30L, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for latch");
+        }
+
+        // then
+        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 30000L, 6);
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic), is(1));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-retry"), is(3));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-error"), is(1));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-invalid"), is(0));
+        verify(itemGroupProcessedSendHandler, times(4)).handleMessage(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getPayload(), is(ITEM_GROUP_PROCESSED_SEND));
+
+        verify(messageProducer, times(4))
+            .sendMessage(any(GenericRecord.class), anyString(), eq(outboundTopic));
+    }
+
+    private void verifyExceptionInEmailSendIsNotRetried(final Class<? extends Exception> exceptionClass)
+        throws IOException, SerializationException, ExecutionException, InterruptedException, TimeoutException {
+
+        // given
+        client.when(request()
+                .withPath(TestConstants.ORDER_NOTIFICATION_REFERENCE)
+                .withMethod(HttpMethod.GET.toString()))
+            .respond(response()
+                .withStatusCode(HttpStatus.OK.value())
+                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .withBody(JsonBody.json(IOUtils.resourceToString(
+                    "/fixtures/digital-certified-copy.json",
+                    StandardCharsets.UTF_8))));
+        embeddedKafkaBroker.consumeFromAllEmbeddedTopics(testConsumer);
+        doThrow(exceptionClass).when(messageProducer)
+            .sendMessage(any(GenericRecord.class), anyString(), eq(outboundTopic));
+
+        // when
+        testProducer.send(new ProducerRecord<>(
+            inboundTopic, 0, System.currentTimeMillis(), SAME_PARTITION_KEY,
+            ITEM_GROUP_PROCESSED_SEND));
+        if (!latch.await(30L, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for latch");
+        }
+
+        // then
+        final ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, 30000L, 6);
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic), is(1));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-retry"), is(0));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-error"), is(0));
+        assertThat(noOfRecordsForTopic(consumerRecords, inboundTopic + "-invalid"), is(1));
+        verify(itemGroupProcessedSendHandler).handleMessage(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getPayload(), is(ITEM_GROUP_PROCESSED_SEND));
+
+        verify(messageProducer)
+            .sendMessage(any(GenericRecord.class), anyString(), eq(outboundTopic));
+    }
+}
+
+

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendConsumerIntegrationTest.java
@@ -1,12 +1,23 @@
 package uk.gov.companieshouse.ordernotification.consumer.itemgroupprocessedsend;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.ITEM_GROUP_PROCESSED_SEND;
 
+import email.email_send;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.AfterAll;
@@ -16,15 +27,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.utility.DockerImageName;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.ordernotification.config.TestConfig;
 import uk.gov.companieshouse.ordernotification.config.TestEnvironmentSetupHelper;
+import uk.gov.companieshouse.ordernotification.fixtures.TestConstants;
 
 @SpringBootTest
 @Import(TestConfig.class)
@@ -35,6 +50,10 @@ class ItemGroupProcessedSendConsumerIntegrationTest {
 
     @Autowired
     private KafkaProducer<String, ItemGroupProcessedSend> itemGroupProcessedSendProducer;
+
+    @Autowired
+    private KafkaConsumer<String, email_send> emailSendConsumer;
+
     private MockServerClient client;
     private CountDownLatch eventLatch;
 
@@ -69,7 +88,19 @@ class ItemGroupProcessedSendConsumerIntegrationTest {
 
     @Test
     @DisplayName("Handles item-group-processed-send message")
-    void testHandlesItemGroupProcessedSendMessage() throws ExecutionException, InterruptedException {
+    void testHandlesItemGroupProcessedSendMessage()
+        throws ExecutionException, InterruptedException, IOException {
+
+        // given
+        client.when(request()
+                .withPath(TestConstants.ORDER_NOTIFICATION_REFERENCE)
+                .withMethod(HttpMethod.GET.toString()))
+            .respond(response()
+                .withStatusCode(HttpStatus.OK.value())
+                .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .withBody(JsonBody.json(IOUtils.resourceToString(
+                    "/fixtures/digital-certified-copy.json",
+                    StandardCharsets.UTF_8))));
 
         // when
         itemGroupProcessedSendProducer.send(new ProducerRecord<>("item-group-processed-send",
@@ -81,6 +112,20 @@ class ItemGroupProcessedSendConsumerIntegrationTest {
         if (!messageHandled) {
             fail("FAILED to handle the item-group-processed-send message produced!");
         }
+
+        eventLatch.await(30, TimeUnit.SECONDS);
+        email_send actual = emailSendConsumer.poll(Duration.ofSeconds(15))
+            .iterator()
+            .next()
+            .value();
+
+        // then
+        assertEquals("order_notification_sender", actual.getAppId());
+        assertEquals("digital_item_ready", actual.getMessageId());
+        assertEquals("digital_item_ready", actual.getMessageType());
+        assertEquals("noreply@companieshouse.gov.uk", actual.getEmailAddress());
+        assertNotNull(actual.getData());
+
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSenderTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/consumer/itemgroupprocessedsend/ItemGroupProcessedSendEmailSenderTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
@@ -34,6 +35,9 @@ class ItemGroupProcessedSendEmailSenderTest {
 
     @InjectMocks
     private ItemGroupProcessedSendEmailSender itemGroupProcessedSendEmailSender;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Test
     void testHandleMessageLogsMessage() {

--- a/src/test/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceOrderNotificationEnricherTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/emailmodel/OrderResourceOrderNotificationEnricherTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.ordernotification.fixtures.TestConstants.ITEM_GROUP_PROCESSED_SEND;
 
 import java.util.Collections;
 import org.hamcrest.Matchers;
@@ -62,6 +63,23 @@ class OrderResourceOrderNotificationEnricherTest {
     }
 
     @Test
+    void testThrowExceptionIfOrdersApiErrorsDuringEnrichmentWithItemGroupProcessedSend()
+        throws OrdersResponseException {
+        //given
+        when(orderRetrievable.getOrderData(anyString())).thenThrow(OrdersResponseException.class);
+        when(loggingUtils.logWithOrderUri(any(), any())).thenReturn(Collections.emptyMap());
+
+        //when
+        Executable actual = () -> enricher.enrich(TestConstants.ORDER_NOTIFICATION_REFERENCE,
+            ITEM_GROUP_PROCESSED_SEND);
+
+        //then
+        assertThrows(OrdersResponseException.class, actual);
+        verify(orderRetrievable).getOrderData(TestConstants.ORDER_NOTIFICATION_REFERENCE);
+        verifyNoInteractions(ordersApiMapper);
+    }
+
+    @Test
     void testLogRuntimeExceptionThrownByMapper() {
         //given
         when(orderRetrievable.getOrderData(anyString())).thenReturn(ordersApiWrappable);
@@ -71,6 +89,24 @@ class OrderResourceOrderNotificationEnricherTest {
 
         //when
         Executable actual = () -> enricher.enrich(TestConstants.ORDER_NOTIFICATION_REFERENCE);
+
+        //then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, actual);
+        verify(logger).error("Failed to map order resource", exception, Collections.emptyMap());
+    }
+
+    @Test
+    void testLogRuntimeExceptionThrownDuringEnrichmentWithItemGroupProcessedSend() {
+        //given
+        when(orderRetrievable.getOrderData(anyString())).thenReturn(ordersApiWrappable);
+        when(ordersApiMapper.mapToEmailSend(any(), any())).thenThrow(
+            IllegalArgumentException.class);
+        when(loggingUtils.logWithOrderUri(any(), any())).thenReturn(Collections.emptyMap());
+        when(loggingUtils.getLogger()).thenReturn(logger);
+
+        //when
+        Executable actual = () -> enricher.enrich(TestConstants.ORDER_NOTIFICATION_REFERENCE,
+            ITEM_GROUP_PROCESSED_SEND);
 
         //then
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.ordernotification.itemstatusupdatenotificationsender;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
+import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceOrderNotificationEnricher;
+import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
+import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
+import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
+import uk.gov.companieshouse.ordernotification.messageproducer.MessageProducer;
+
+@ExtendWith(MockitoExtension.class)
+class ItemGroupProcessedSendSenderServiceTest {
+
+    @InjectMocks
+    private ItemGroupProcessedSendSenderService itemGroupProcessedSendSenderService;
+
+    @Mock
+    private MessageProducer producer;
+
+    @Mock
+    private ItemGroupProcessedSend event;
+
+    @Mock
+    private EmailSend emailSendModel;
+
+    @Mock
+    private LoggingUtils loggingUtils;
+
+    @Mock
+    private OrderResourceOrderNotificationEnricher orderEnricher;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Test
+    void testHandleEventNoExceptionsThrown() {
+
+        // given
+        when(loggingUtils.getLogger()).thenReturn(logger);
+
+        // when
+        itemGroupProcessedSendSenderService.handleEvent(event);
+
+        // then
+        verify(logger).debug(
+            eq("Successfully enriched item group item status update; notifying email sender"),
+            any());
+
+        verify(applicationEventPublisher).publishEvent(any(SendEmailEvent.class));
+    }
+
+    @Test
+    void testRetryableErrorExceptionIsLoggedAndPropagated() {
+
+        // given
+        when(orderEnricher.enrich(anyString(), eq(event))).thenThrow(
+            new RetryableErrorException("Test exception", new Throwable("Test throwable")));
+        when(loggingUtils.getLogger()).thenReturn(logger);
+
+        // when and then
+        final RetryableErrorException exception = assertThrows(RetryableErrorException.class,
+            () -> itemGroupProcessedSendSenderService.handleEvent(event));
+
+        verify(logger).error(eq("Failed to enrich item group item status update"), eq(exception),
+            anyMap());
+        assertThat(exception.getMessage(), is("Test exception"));
+        assertThat(exception.getCause().getMessage(), is("Test throwable"));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import uk.gov.companieshouse.itemgroupprocessedsend.Item;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
@@ -52,11 +53,15 @@ class ItemGroupProcessedSendSenderServiceTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
+    @Mock
+    private Item item;
+
     @Test
     void testHandleEventNoExceptionsThrown() {
 
         // given
         when(loggingUtils.getLogger()).thenReturn(logger);
+        when(event.getItem()).thenReturn(item);
 
         // when
         itemGroupProcessedSendSenderService.handleEvent(event);
@@ -76,6 +81,7 @@ class ItemGroupProcessedSendSenderServiceTest {
         when(orderEnricher.enrich(anyString(), eq(event))).thenThrow(
             new RetryableErrorException("Test exception", new Throwable("Test throwable")));
         when(loggingUtils.getLogger()).thenReturn(logger);
+        when(event.getItem()).thenReturn(item);
 
         // when and then
         final RetryableErrorException exception = assertThrows(RetryableErrorException.class,

--- a/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import uk.gov.companieshouse.itemgroupprocessedsend.ItemGroupProcessedSend;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
-import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceOrderNotificationEnricher;
+import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceItemReadyNotificationEnricher;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
 import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
@@ -44,7 +44,7 @@ class ItemGroupProcessedSendSenderServiceTest {
     private LoggingUtils loggingUtils;
 
     @Mock
-    private OrderResourceOrderNotificationEnricher orderEnricher;
+    private OrderResourceItemReadyNotificationEnricher orderEnricher;
 
     @Mock
     private Logger logger;

--- a/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ordernotification/itemstatusupdatenotificationsender/ItemGroupProcessedSendSenderServiceTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.ordernotification.consumer.orderreceived.RetryableErrorException;
 import uk.gov.companieshouse.ordernotification.emailmodel.OrderResourceItemReadyNotificationEnricher;
 import uk.gov.companieshouse.ordernotification.emailsender.EmailSend;
-import uk.gov.companieshouse.ordernotification.emailsender.SendEmailEvent;
+import uk.gov.companieshouse.ordernotification.emailsender.SendItemReadyEmailEvent;
 import uk.gov.companieshouse.ordernotification.logging.LoggingUtils;
 import uk.gov.companieshouse.ordernotification.messageproducer.MessageProducer;
 
@@ -66,7 +66,7 @@ class ItemGroupProcessedSendSenderServiceTest {
             eq("Successfully enriched item group item status update; notifying email sender"),
             any());
 
-        verify(applicationEventPublisher).publishEvent(any(SendEmailEvent.class));
+        verify(applicationEventPublisher).publishEvent(any(SendItemReadyEmailEvent.class));
     }
 
     @Test

--- a/src/test/resources/fixtures/digital-certified-copy.json
+++ b/src/test/resources/fixtures/digital-certified-copy.json
@@ -1,0 +1,80 @@
+{
+  "payment_reference": "4i6e9pKVkheYrtA",
+  "etag": "630c1b94321a099cbcc5a21e2f1a76d6a8676d43",
+  "delivery_details": {
+    "country": "UK",
+    "forename": "John",
+    "locality": "Cardiff",
+    "postal_code": "CF14 3UZ",
+    "region": "Cardiff",
+    "surname": "Test",
+    "address_line_1": "1 Crown Way",
+    "address_line_2": "Maindy"
+  },
+  "items": [
+    {
+      "id": "CCD-768116-517930",
+      "company_name": "CERTIFIED DOCUMENTS TEST COMPANY LIMITED",
+      "company_number": "10371283",
+      "description": "certified copy for company 10371283",
+      "description_identifier": "certified-copy",
+      "description_values": {
+        "company_number": "10371283",
+        "certified-copy": "certified copy for company 10371283"
+      },
+      "item_costs": [
+        {
+          "discount_applied": "0",
+          "item_cost": "15",
+          "calculated_cost": "15",
+          "product_type": "certified-copy"
+        }
+      ],
+      "item_options": {
+        "delivery_method": "postal",
+        "delivery_timescale": "standard",
+        "filing_history_documents": [
+          {
+            "filing_history_date": "2019-11-23",
+            "filing_history_description": "capital-allotment-shares",
+            "filing_history_description_values": {
+              "date": "2019-11-10",
+              "capital": [
+                {
+                  "figure": "34,253,377",
+                  "currency": "GBP"
+                }
+              ]
+            },
+            "filing_history_id": "OTAwMzQ1NjM2M2FkaXF6a6N4",
+            "filing_history_type": "SH01",
+            "filing_history_cost": "15"
+          }
+        ]
+      },
+      "etag": "7843c9fc51087f6ae12a9b86196b665bb8f3fa83",
+      "kind": "item#certified-copy",
+      "links": {
+        "self": "/orderable/certified-copies/CCD-768116-517930"
+      },
+      "quantity": 1,
+      "item_uri": "/orderable/certified-copies/CCD-768116-517930",
+      "status": "processing",
+      "postage_cost": "0",
+      "total_item_cost": "15",
+      "digital_document_location": "s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf",
+      "postal_delivery": true
+    }
+  ],
+  "kind": "order",
+  "total_order_cost": "15",
+  "reference": "ORD-065216-517934",
+  "ordered_at": "2022-05-03T23:31:47.486",
+  "ordered_by": {
+    "email": "testautomation1@test.companieshouse.gov.uk",
+    "id": "xBjfyx0li07r6test1"
+  },
+  "links": {
+    "self": "/orders/ORD-065216-517934"
+  }
+}


### PR DESCRIPTION
* These changes trigger the sending out of an item ready `email-send` Kafka message in response to the handling of an incoming `item-group-processed-send` message.
* They have been implemented in a manner that is in line with the Spring events based architecture already present in the application.
* In testing in Tilt, this results in `Your digital item CCD-768116-517930 from order ORD-065216-517934 is ready` emails being dispatched.
* Testing in Tilt and automated tests verify that the production of these email messages is repeated resiliently should certain issues occur during the getting of the order data used to enrich the email messages, or during the production/sending of the email messages themselves.  

![your digital item is ready](https://github.com/companieshouse/order-notification-sender/assets/54801196/71eb1b04-234b-46e2-b1ac-c2676f1e75fd)
