### PR TITLE
upgrade modules and provider versions, applied terraform fmt

### DIFF
--- a/terraform/groups/ecs-service/.terraform.lock.hcl
+++ b/terraform/groups/ecs-service/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.52.0"
+  constraints = ">= 4.0.0, >= 6.0.0, < 7.0.0"
+  hashes = [
+    "h1:8m5zm0JaUac+YikXZoZDTV7R0iYL+q3IvTL4Ac8GfDA=",
+    "h1:Dg9X3Gde96OCT3TovLKAKumnR64VqIIQ37m/9NRJ00Y=",
+    "zh:1ab1d78f2336fed42b4e13fa0077a0be9d86a7899897cda5b9f1a60051ec2e93",
+    "zh:1df11f5f252030803939a1c778931dbdcee1b1070b38b98d9a8cbfc26c2aeb8e",
+    "zh:20ec9af03c0c1f2f8582a8805d43a4cd1a0a65082308e00f025d87605715a88f",
+    "zh:2d5562ed0e7cb0892fb537c7989d25fdde1d0ac1f3a768ba15fa087985f2a0f5",
+    "zh:40d64f668961a172355c3d11d258e19172ffafb421c40d89266b129ed8f92a5d",
+    "zh:497792bccc33001247473bc32a148c067982cb3d245b8f3610afb920635d2235",
+    "zh:8011f9167082af74ed9257582a83d54e889388656597721b2691797f1dd6fb58",
+    "zh:8b10d1bbca51b0da1e1be0967ce75b039f2d5d86f2ca7339994a92d35cdf47a8",
+    "zh:9549647dbf7c913512c26fed6badd7bf24a29a36c2bd308536849303a85427da",
+    "zh:97c4b726cdbe48166f4b9e6a1230312a7933dc19dd139d941ca6aca86706eb33",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a484bc8166278b546bfe53698fa9e0a919dffe3bfda3c8bf8a0fc6811b5b9e66",
+    "zh:aa96e76bd9f93e5395a553fccec485554a74acae46b3834b1296374eba4f010f",
+    "zh:cf290ee3d0dfe91b596445f860440d9f18826f7395ff785f83f70d36cedadd1c",
+    "zh:d56b6a79207663673f66d9ed378d705c1bd1b4d117eeb5e2be3938cf1b75b7be",
+    "zh:febef068317f8e49bd438ccdf2f54345fc3bc4b80a2699d9ab3c449d7e521d8e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.10.1"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:gE6FVZ+6NXhwd9bOnL0ARFNw94dDiAICRxoXXuRTuas=",
+    "h1:lyFssgWG/91rFC++zoiJQDaqhzWieLL64bIF6+53Hq4=",
+    "zh:0de49889bc7cfb66f9004651252e4c38acb0c927335ce0cbe1ee59a576030a44",
+    "zh:1875cbcbac4bf19f2e9f9bd6f7a4589419f65969676c879b5c80ca4823818011",
+    "zh:32f51e4eae2157a3c56ff40cd72f218776a9a8cc2151a6d78a36078c87243ac7",
+    "zh:7674d317e9337da84daec86d1b4610392eb3838369198011fe79b6980acb8632",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f9b9322cf83ea17ae218199bb9f482699e2ea481ba1c2e4c9f81dffc0e9a43c",
+    "zh:808dcb981408ef066a0c4cc412ba181924616157c29d5b404b7a5c6d6d6e7386",
+    "zh:8bbd07729da50f55606ae7a3a8ef0624ace110da31465753e5552abbde43233a",
+    "zh:9c798262c364afcef6630b2d290c19b763071c561b90cf051d87ad56b369cd89",
+    "zh:d90fcc9b1e740ee0c0ea6e123ec964f2e1cdbf65a1dba1786e65e2a827880e72",
+    "zh:f07e029e576786b6d4af488fdb7da2a4bbd0509e6dacfbd73230a1503e3c085e",
+    "zh:f2e5070b9a7fca6a0fe857db4d3df0f2a182567178058b764bdbfb4199ae113b",
+  ]
+}

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -41,7 +41,7 @@ data "aws_ssm_parameters_by_path" "secrets" {
 # create a list of secrets names to retrieve them in a nicer format and lookup each secret by name
 data "aws_ssm_parameter" "secret" {
   for_each = toset(data.aws_ssm_parameters_by_path.secrets.names)
-  name = each.key
+  name     = each.key
 }
 
 # retrieve all global secrets for this env using global path

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,20 +1,20 @@
 # Define all hardcoded local variable and local variables looked up from data resources
 locals {
-  stack_name                 = "order-service" # this must match the stack name the service deploys into
-  name_prefix                = "${local.stack_name}-${var.environment}"
-  global_prefix              = "global-${var.environment}"
-  service_name               = "order-notification-sender"
-  service_name_old_kafka     = "order-notification-sender-old-kafka"
+  stack_name             = "order-service" # this must match the stack name the service deploys into
+  name_prefix            = "${local.stack_name}-${var.environment}"
+  global_prefix          = "global-${var.environment}"
+  service_name           = "order-notification-sender"
+  service_name_old_kafka = "order-notification-sender-old-kafka"
 
-  container_port             = "8080"
-  docker_repo                = "order-notification-sender"
-  kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
-  healthcheck_path           = "/healthcheck" # healthcheck path for order-notification-sender
-  healthcheck_matcher        = "200"
-  vpc_name                   = local.stack_secrets["vpc_name"]
-  s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
-  app_environment_filename   = "order-notification-sender.env"
-  app_environment_filename_old_kafka    = "order-notification-sender-old-kafka.env"
+  container_port                     = "8080"
+  docker_repo                        = "order-notification-sender"
+  kms_alias                          = "alias/${var.aws_profile}/environment-services-kms"
+  healthcheck_path                   = "/healthcheck" # healthcheck path for order-notification-sender
+  healthcheck_matcher                = "200"
+  vpc_name                           = local.stack_secrets["vpc_name"]
+  s3_config_bucket                   = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
+  app_environment_filename           = "order-notification-sender.env"
+  app_environment_filename_old_kafka = "order-notification-sender-old-kafka.env"
 
   use_set_environment_files  = var.use_set_environment_files
   application_subnet_ids     = data.aws_subnets.application.ids
@@ -41,7 +41,7 @@ locals {
 
   ssm_global_version_map = [
     for sec in data.aws_ssm_parameter.global_secret :
-      { "name"  = "GLOBAL_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", "value" = sec.version }
+    { "name" = "GLOBAL_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", "value" = sec.version }
   ]
 
   service_secrets_arn_map = {
@@ -55,13 +55,13 @@ locals {
 
   ssm_service_version_map = [
     for sec in module.secrets.secrets :
-      { "name"  = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", "value" = sec.version }
+    { "name" = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}", "value" = sec.version }
   ]
 
   # secrets to go in list
-  task_secrets = concat(local.global_secret_list,local.service_secret_list)
+  task_secrets = concat(local.global_secret_list, local.service_secret_list)
 
-  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
+  task_environment = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { "name" : "PORT", "value" : local.container_port }
   ])
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -3,23 +3,23 @@ provider "aws" {
 }
 
 terraform {
-  backend "s3" {
-  }
-  required_version = "~> 1.3"
+  required_version = ">= 1.3.0, < 2.0.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.54.0"
+      version = ">= 6.0, < 7.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.18.0"
+      version = ">= 5.0, < 6.0"
     }
   }
+  backend "s3" {}
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.336"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.390"
 
   # Environmental configuration
   environment             = var.environment
@@ -69,26 +69,26 @@ module "ecs-service" {
 }
 
 module "ecs-service-old-kafka" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.336"
-  count  = var.create_old_kafka_service? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.390"
+  count  = var.create_old_kafka_service ? 1 : 0
 
   # Environmental configuration
-  environment             = var.environment
-  aws_region              = var.aws_region
-  aws_profile             = var.aws_profile
-  vpc_id                  = data.aws_vpc.vpc.id
-  ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
-  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
-  batch_service           = true
+  environment                             = var.environment
+  aws_region                              = var.aws_region
+  aws_profile                             = var.aws_profile
+  vpc_id                                  = data.aws_vpc.vpc.id
+  ecs_cluster_id                          = data.aws_ecs_cluster.ecs_cluster.id
+  task_execution_role_arn                 = data.aws_iam_role.ecs_cluster_iam_role.arn
+  batch_service                           = true
   cloudwatch_unhealthy_host_count_enabled = false
   cloudwatch_healthy_host_count_enabled   = false
   cloudwatch_response_time_enabled        = false
   cloudwatch_http_5xx_error_count_enabled = false
 
   # ECS Task container health check
-  use_task_container_healthcheck = true
-  healthcheck_path               = local.healthcheck_path
-  healthcheck_matcher            = local.healthcheck_matcher
+  use_task_container_healthcheck    = true
+  healthcheck_path                  = local.healthcheck_path
+  healthcheck_matcher               = local.healthcheck_matcher
   health_check_grace_period_seconds = 180
 
   # Docker container details
@@ -102,35 +102,34 @@ module "ecs-service-old-kafka" {
   name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count                 = var.desired_task_count
-  max_task_count                     = var.max_task_count
-  min_task_count                     = var.min_task_count
-  required_cpus                      = var.required_cpus
-  required_memory                    = var.required_memory
-  service_autoscale_enabled          = var.service_autoscale_enabled
-  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
+  desired_task_count                   = var.desired_task_count
+  max_task_count                       = var.max_task_count
+  min_task_count                       = var.min_task_count
+  required_cpus                        = var.required_cpus
+  required_memory                      = var.required_memory
+  service_autoscale_enabled            = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
   service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
   service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
-  service_scaledown_schedule         = var.service_scaledown_schedule
-  service_scaleup_schedule           = var.service_scaleup_schedule
-  use_capacity_provider              = var.use_capacity_provider
-  use_fargate                        = var.use_fargate
-  fargate_subnets                    = local.application_subnet_ids
+  service_scaledown_schedule           = var.service_scaledown_schedule
+  service_scaleup_schedule             = var.service_scaleup_schedule
+  use_capacity_provider                = var.use_capacity_provider
+  use_fargate                          = var.use_fargate
+  fargate_subnets                      = local.application_subnet_ids
 
   # Cloudwatch
   cloudwatch_alarms_enabled = false
 
   # Service environment variable and secret configs
-  task_environment            = local.task_environment
-  task_secrets                = local.task_secrets
-  app_environment_filename    = local.app_environment_filename_old_kafka
-  use_set_environment_files   = local.use_set_environment_files
+  task_environment          = local.task_environment
+  task_secrets              = local.task_secrets
+  app_environment_filename  = local.app_environment_filename_old_kafka
+  use_set_environment_files = local.use_set_environment_files
 }
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.336"
+  source = "git@github.com:companieshouse/terraform-modules//aws/parameter-store?ref=1.0.390"
 
   name_prefix = "${local.service_name}-${var.environment}"
-  environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
   secrets     = nonsensitive(local.service_secrets)
 }

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -28,19 +28,19 @@ variable "docker_registry" {
 # Service performance and scaling configs
 # ------------------------------------------------------------------------------
 variable "desired_task_count" {
-  type = number
+  type        = number
   description = "The desired ECS task count for this service"
-  default = 1 # defaulted low for dev environments, override for production
+  default     = 1 # defaulted low for dev environments, override for production
 }
 variable "required_cpus" {
-  type = number
+  type        = number
   description = "The required cpu resource for this service. 1024 here is 1 vCPU"
-  default = 512 # defaulted low for dev environments, override for production
+  default     = 512 # defaulted low for dev environments, override for production
 }
 variable "required_memory" {
-  type = number
+  type        = number
   description = "The required memory for this service"
-  default = 1024 # defaulted low for node service in dev environments, override for production
+  default     = 1024 # defaulted low for node service in dev environments, override for production
 
 }
 
@@ -82,7 +82,7 @@ variable "service_scaledown_schedule" {
   # Typically used to stop all tasks in a service to save resource costs overnight.
   # E.g. a value of '55 19 * * ? *' would be Mon-Sun 7:55pm.  An empty string indicates that no schedule should be created.
 
-  default     = ""
+  default = ""
 }
 variable "service_scaleup_schedule" {
   type        = string
@@ -90,7 +90,7 @@ variable "service_scaleup_schedule" {
   # Typically used to start all tasks in a service after it has been shutdown overnight.
   # E.g. a value of '5 6 * * ? *' would be Mon-Sun 6:05am.  An empty string indicates that no schedule should be created.
 
-  default     = ""
+  default = ""
 }
 
 # ----------------------------------------------------------------------
@@ -148,7 +148,7 @@ variable "order_notification_sender_old_kafka_version" {
 # Kafka Consumer Configurations
 # ------------------------------------------------------------------------------
 variable "backoff_delay" {
-  default   = 32000
-  type      = number
+  default     = 32000
+  type        = number
   description = "The delay in milliseconds between message republish attempts."
 }

--- a/terraform/groups/ecs-service/vault-providers/userpass
+++ b/terraform/groups/ecs-service/vault-providers/userpass
@@ -1,11 +1,11 @@
 variable "hashicorp_vault_username" {
   description = "The username used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 variable "hashicorp_vault_password" {
   description = "The password used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 provider "vault" {


### PR DESCRIPTION
### Related Jira tickets

- ASM-2284

### General
- Upgraded `ecs service` module to the latest ref
- Replaced the `secrets` module `aws/ecs/secrets` with `aws/parameter-store`
- Raised provider constraints: AWS `>= 6.0, < 7.0` , Vault `>= 5.0, < 6.0`
- Set required_version to `>= 1.3.0, < 2.0.0`
- Regenerated .`terraform.lock.hcl`
- Applied `terraform fmt`

### Plan summary
`Plan: 1 to add, 1 to change, 1 to destroy`